### PR TITLE
Port screenshot generator from original design history

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "rollup": "^1.27.8",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",
-    "sharp": "^0.23.4"
+    "sharp": "^0.23.4",
+    "webshot": "^0.18.0"
   },
   "devDependencies": {
     "standard": "^14.3.1"

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -9,7 +9,6 @@
 
 // Dependencies
 const fs = require('fs');
-const sharp = require('sharp');
 
 // Arguments
 const directoryName = process.argv.slice(-1)[0];
@@ -20,7 +19,6 @@ var title = directoryName.split('/').pop().replace(/-/g, ' ');
 title = title.charAt(0).toUpperCase() + title.slice(1)
 const imageDirectory = `app/assets/images/${directoryName}`;
 const indexDirectory = `app/views/${directoryName}`;
-const thumbnailDirectory = `${imageDirectory}/thumbnails`;
 
 var paths = [];
 
@@ -29,7 +27,6 @@ function start() {
   makeDirectories();
   getExistingImages();
   generatePage();
-  generateThumbnails();
 }
 
 function warnIfNoArguments(title) {
@@ -44,10 +41,6 @@ function warnIfNoArguments(title) {
 function makeDirectories() {
   if (!fs.existsSync(imageDirectory)){
     fs.mkdirSync(imageDirectory);
-  }
-
-  if (!fs.existsSync(thumbnailDirectory)){
-    fs.mkdirSync(thumbnailDirectory);
   }
 
   if (!fs.existsSync(indexDirectory)){
@@ -70,13 +63,10 @@ function getExistingImages() {
     var image = {
       title: title.charAt(0).toUpperCase() + title.slice(1),
       id: id,
-      file: `${imageDirectory}/${file}`,
-      thumbnailFile: `${thumbnailDirectory}/${file}`
+      file: `${imageDirectory}/${file}`
     }
 
     image.src = image.file.replace('app/assets', '/public');
-    image.thumbnailSrc = image.thumbnailFile.replace('app/assets', '/public');
-
     paths.push(image);
   });
 }
@@ -121,12 +111,6 @@ function generatePage() {
       console.log(`Index generated: ${indexDirectory}/index.html`);
     }
   );
-}
-
-function generateThumbnails() {
-  paths.forEach(function(item, index) {
-    sharp(item.file).resize(630, null).toFile(item.thumbnailFile);
-  });
 }
 
 start();

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -1,0 +1,132 @@
+/*
+  Usage:
+  * Put images into `app/assets/directory-name`
+  * Name them with 01-, 02- prefixes
+
+  Run:
+  node scripts/generate.js name-of-directory-holding-images
+*/
+
+// Dependencies
+const fs = require('fs');
+const sharp = require('sharp');
+
+// Arguments
+const directoryName = process.argv.slice(-1)[0];
+warnIfNoArguments();
+
+// Ignore any directories when generating a title
+var title = directoryName.split('/').pop().replace(/-/g, ' ');
+title = title.charAt(0).toUpperCase() + title.slice(1)
+const imageDirectory = `app/assets/images/${directoryName}`;
+const indexDirectory = `app/views/${directoryName}`;
+const thumbnailDirectory = `${imageDirectory}/thumbnails`;
+
+var paths = [];
+
+// Run
+function start() {
+  makeDirectories();
+  getExistingImages();
+  generatePage();
+  generateThumbnails();
+}
+
+function warnIfNoArguments(title) {
+  // TODO: Use a better check for an argument
+  if (directoryName.startsWith('/Users')) {
+    console.log('No arguments set');
+    console.log('Please set a title: `node scripts/screenshot.js "Title of page"`');
+    return;
+  }
+}
+
+function makeDirectories() {
+  if (!fs.existsSync(imageDirectory)){
+    fs.mkdirSync(imageDirectory);
+  }
+
+  if (!fs.existsSync(thumbnailDirectory)){
+    fs.mkdirSync(thumbnailDirectory);
+  }
+
+  if (!fs.existsSync(indexDirectory)){
+    fs.mkdirSync(indexDirectory);
+  }
+}
+
+function getExistingImages() {
+  const files = fs.readdirSync(imageDirectory);
+
+  files.forEach((file, index) => {
+    if (!(/\.(png|jpg)$/.test(file))) {
+      console.log('Ignoring: ' + file);
+      return;
+    }
+
+    var id = file.replace(/\.(png|jpg)$/, '');
+    var title = id.replace(/^\d{2}-/, '').replace(/-/g, ' ');
+
+    var image = {
+      title: title.charAt(0).toUpperCase() + title.slice(1),
+      id: id,
+      file: `${imageDirectory}/${file}`,
+      thumbnailFile: `${thumbnailDirectory}/${file}`
+    }
+
+    image.src = image.file.replace('app/assets', '/public');
+    image.thumbnailSrc = image.thumbnailFile.replace('app/assets', '/public');
+
+    paths.push(image);
+  });
+}
+
+function generatePage() {
+  var template = '';
+  const templateStart = `{% extends "layout.html" %}
+{% set title = '${title}' %}
+{% block pageTitle %}{{ title }}{% endblock %}
+{% block breadcrumbs %}{{ designHistory.breadcrumbs(breadcrumbItems()) }}{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+`;
+
+  const templateEnd = `
+{% endblock %}
+`;
+
+  var contents = `
+  {% set contents = [`;
+
+  const endContents = `
+  ] %}
+  {{ designHistory.screenshotContents(contents) }}
+  `;
+
+  paths.forEach(function(item, index) {
+    template += `
+  {{ designHistory.screenshot('${item.title}', '${item.id}', '${item.thumbnailSrc}', '${item.src}', '') }}
+`;
+
+    contents += `${index > 0 ? ', ': ''}
+    { text: '${item.title}', id: '${item.id}' }`;
+  });
+
+  fs.writeFile(
+    `${indexDirectory}/index.html`,
+    templateStart + contents + endContents + template + templateEnd,
+    function(err) {
+      if (err) { return console.log(err); }
+      console.log(`Index generated: ${indexDirectory}/index.html`);
+    }
+  );
+}
+
+function generateThumbnails() {
+  paths.forEach(function(item, index) {
+    sharp(item.file).resize(630, null).toFile(item.thumbnailFile);
+  });
+}
+
+start();

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -1,0 +1,146 @@
+/*
+  Usage:
+  Set domain to the website you want to screenshot, eg localhost:3000
+  Set paths to an array of named paths (see example)
+
+  Run:
+  node scripts/screenshot.js name-of-directory
+
+  Example paths:
+  paths = [
+    { title: 'Index page', path: '/'},
+    { title: 'Terms and conditions', path: '/terms-conditions'}
+  ]
+*/
+const paths = [];
+const domain = 'http://localhost:3000';
+
+// Dependencies
+const webshot = require('webshot');
+const fs = require('fs');
+const sharp = require('sharp');
+
+// Arguments
+const directoryName = process.argv.slice(-1)[0];
+warnIfNoArguments();
+
+// Ignore any directories when generating a title
+var title = directoryName.split('/').pop().replace(/-/g, ' ');
+title = title.charAt(0).toUpperCase() + title.slice(1)
+const imageDirectory = `app/assets/images/${directoryName}`;
+const indexDirectory = `app/views/${directoryName}`;
+const thumbnailDirectory = `${imageDirectory}/thumbnails`;
+
+// Run
+function start() {
+  makeDirectories();
+  decoratePaths();
+  generatePage();
+  takeScreenshots();
+}
+
+function warnIfNoArguments(title) {
+  // TODO: Use a better check for an argument
+  if (directoryName.startsWith('/Users')) {
+    console.log('No arguments set');
+    console.log('Please set a directory name: `node scripts/screenshot.js "name-of-directory"`');
+    return;
+  }
+}
+
+function makeDirectories() {
+  if (!fs.existsSync(imageDirectory)){
+    fs.mkdirSync(imageDirectory);
+  }
+
+  if (!fs.existsSync(thumbnailDirectory)){
+    fs.mkdirSync(thumbnailDirectory);
+  }
+
+  if (!fs.existsSync(indexDirectory)){
+    fs.mkdirSync(indexDirectory);
+  }
+}
+
+function decoratePaths() {
+  paths.forEach(function(item, index) {
+    item.id = item.title.replace(/ +/g, '-').toLowerCase();
+    item.file = `${imageDirectory}/${item.id}.png`;
+    item.thumbnailFile = `${thumbnailDirectory}/${item.id}.png`;
+    item.src = item.file.replace('app/assets', '/public');
+    item.thumbnailSrc = item.thumbnailFile.replace('app/assets', '/public');
+  });
+}
+
+function takeScreenshots() {
+  // https://github.com/brenden/node-webshot
+  const webshotOptions = {
+    phantomConfig: {
+      'ignore-ssl-errors': 'true'
+    },
+    windowSize: {
+      width: 1200,
+      height: 800
+    },
+    shotSize: {
+      width: 'window',
+      height: 'all'
+    }
+  }
+
+  paths.forEach(function(item, index) {
+    webshot(
+      domain + item.path,
+      item.file,
+      webshotOptions,
+      function(err) {
+        sharp(item.file).resize(630, null).toFile(item.thumbnailFile);
+        console.log(`${domain + item.path} \n >> ${item.file}`);
+      }
+    );
+  });
+}
+
+function generatePage() {
+  var template = '';
+  const templateStart = `{% extends "layout.html" %}
+{% set title = '${title}' %}
+{% block pageTitle %}{{ title }}{% endblock %}
+{% block breadcrumbs %}{{ designHistory.breadcrumbs(breadcrumbItems()) }}{% endblock %}
+
+{% block content %}
+  <h1 class="govuk-heading-xl">{{ title }}</h1>
+`;
+
+  const templateEnd = `
+{% endblock %}
+`;
+
+  var contents = `
+  {% set contents = [`;
+
+  const endContents = `
+  ] %}
+  {{ designHistory.screenshotContents(contents) }}
+  `;
+
+  paths.forEach(function(item, index) {
+    template += `
+  {{ designHistory.screenshot('${item.title}', '${item.id}', '${item.thumbnailSrc}', '${item.src}', '') }}
+`;
+
+    contents += `${index > 0 ? ', ': ''}
+    { text: '${item.title}', id: '${item.id}' }`;
+  });
+
+  fs.writeFile(
+    `${indexDirectory}/index.html`,
+    templateStart + contents + endContents + template + templateEnd,
+    function(err) {
+      if (err) { return console.log(err); }
+      console.log(`Index generated: ${indexDirectory}/index.html`);
+    }
+  );
+}
+
+start();

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -18,7 +18,6 @@ const domain = 'http://localhost:3000';
 // Dependencies
 const webshot = require('webshot');
 const fs = require('fs');
-const sharp = require('sharp');
 
 // Arguments
 const directoryName = process.argv.slice(-1)[0];
@@ -29,7 +28,6 @@ var title = directoryName.split('/').pop().replace(/-/g, ' ');
 title = title.charAt(0).toUpperCase() + title.slice(1)
 const imageDirectory = `app/assets/images/${directoryName}`;
 const indexDirectory = `app/views/${directoryName}`;
-const thumbnailDirectory = `${imageDirectory}/thumbnails`;
 
 // Run
 function start() {
@@ -53,10 +51,6 @@ function makeDirectories() {
     fs.mkdirSync(imageDirectory);
   }
 
-  if (!fs.existsSync(thumbnailDirectory)){
-    fs.mkdirSync(thumbnailDirectory);
-  }
-
   if (!fs.existsSync(indexDirectory)){
     fs.mkdirSync(indexDirectory);
   }
@@ -66,9 +60,7 @@ function decoratePaths() {
   paths.forEach(function(item, index) {
     item.id = item.title.replace(/ +/g, '-').toLowerCase();
     item.file = `${imageDirectory}/${item.id}.png`;
-    item.thumbnailFile = `${thumbnailDirectory}/${item.id}.png`;
     item.src = item.file.replace('app/assets', '/public');
-    item.thumbnailSrc = item.thumbnailFile.replace('app/assets', '/public');
   });
 }
 
@@ -94,7 +86,6 @@ function takeScreenshots() {
       item.file,
       webshotOptions,
       function(err) {
-        sharp(item.file).resize(630, null).toFile(item.thumbnailFile);
         console.log(`${domain + item.path} \n >> ${item.file}`);
       }
     );
@@ -126,7 +117,7 @@ function generatePage() {
 
   paths.forEach(function(item, index) {
     template += `
-  {{ designHistory.screenshot('${item.title}', '${item.id}', '${item.thumbnailSrc}', '${item.src}', '') }}
+  {{ designHistory.screenshot('${item.title}', '${item.id}', '${item.src}', '${item.src}', '') }}
 `;
 
     contents += `${index > 0 ? ', ': ''}

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -5,6 +5,8 @@
 
   Run:
   node scripts/screenshot.js name-of-directory
+  or
+  node scripts/screenshot.js apply-for-teacher-training/name-of-directory
 
   Example paths:
   paths = [
@@ -12,7 +14,10 @@
     { title: 'Terms and conditions', path: '/terms-conditions'}
   ]
 */
-const paths = [];
+const paths = [
+  { title: 'Index page', path: '/'}
+];
+const { DateTime } = require('luxon')
 const domain = 'http://localhost:3000';
 
 // Dependencies
@@ -21,13 +26,16 @@ const fs = require('fs');
 
 // Arguments
 const directoryName = process.argv.slice(-1)[0];
+
 warnIfNoArguments();
 
-// Ignore any directories when generating a title
-var title = directoryName.split('/').pop().replace(/-/g, ' ');
+const deepestDirectory = directoryName.split('/').pop()
+
+var title = deepestDirectory.replace(/-/g, ' ');
 title = title.charAt(0).toUpperCase() + title.slice(1)
-const imageDirectory = `app/assets/images/${directoryName}`;
-const indexDirectory = `app/views/${directoryName}`;
+
+const imageDirectory = `app/images/${directoryName}`;
+const postDirectory = `app/posts/${directoryName}`.replace("/" + deepestDirectory, '');
 
 // Run
 function start() {
@@ -51,8 +59,8 @@ function makeDirectories() {
     fs.mkdirSync(imageDirectory);
   }
 
-  if (!fs.existsSync(indexDirectory)){
-    fs.mkdirSync(indexDirectory);
+  if (!fs.existsSync(postDirectory)){
+    fs.mkdirSync(postDirectory);
   }
 }
 
@@ -94,42 +102,37 @@ function takeScreenshots() {
 
 function generatePage() {
   var template = '';
-  const templateStart = `{% extends "layout.html" %}
-{% set title = '${title}' %}
-{% block pageTitle %}{{ title }}{% endblock %}
-{% block breadcrumbs %}{{ designHistory.breadcrumbs(breadcrumbItems()) }}{% endblock %}
+  const templateStart = `---
+title: ${title}
+description:
+tags:
+---
 
-{% block content %}
-  <h1 class="govuk-heading-xl">{{ title }}</h1>
-`;
+## Screenshots
+
+{% from "gallery/macro.njk" import appGallery %}
+{{ appGallery({
+  path: page.filePathStem | replace("/posts", "/images"),
+  items: [`;
 
   const templateEnd = `
-{% endblock %}
+  ]
+}) }}
 `;
-
-  var contents = `
-  {% set contents = [`;
-
-  const endContents = `
-  ] %}
-  {{ designHistory.screenshotContents(contents) }}
-  `;
 
   paths.forEach(function(item, index) {
-    template += `
-  {{ designHistory.screenshot('${item.title}', '${item.id}', '${item.src}', '${item.src}', '') }}
-`;
-
-    contents += `${index > 0 ? ', ': ''}
-    { text: '${item.title}', id: '${item.id}' }`;
+    template += `${index > 0 ? ', ': ''}
+    { text: "${item.title}" }`;
   });
 
+  const filename = `${postDirectory}/${DateTime.local().toFormat('yyyy-MM-dd')}-${deepestDirectory}.md`
+
   fs.writeFile(
-    `${indexDirectory}/index.html`,
-    templateStart + contents + endContents + template + templateEnd,
+    filename,
+    templateStart + template + templateEnd,
     function(err) {
       if (err) { return console.log(err); }
-      console.log(`Index generated: ${indexDirectory}/index.html`);
+      console.log(`Page generated: ${filename}`);
     }
   );
 }


### PR DESCRIPTION
Port two scripts:
1. Script to capture screenshots of webpages and make an index page of them
2. Script to generate an index page from an existing directory of screenshots

Ported from https://github.com/DFE-Digital/bat-design-history/tree/master/scripts

This makes the scripts work, but doesn't yet make the scripts more usable.