### PR TITLE
Load macros with context, move path logic into macro

### DIFF
--- a/app/_components/figure/template.njk
+++ b/app/_components/figure/template.njk
@@ -1,5 +1,5 @@
-{%- from "../embed/macro.njk" import appEmbed -%}
-{%- from "../image/macro.njk" import appImage -%}
+{%- from "../embed/macro.njk" import appEmbed with context -%}
+{%- from "../image/macro.njk" import appImage with context -%}
 <figure class="app-figure">
 {% if params.embed %}
   {{ appEmbed({

--- a/app/_components/gallery/template.njk
+++ b/app/_components/gallery/template.njk
@@ -1,4 +1,4 @@
-{%- from "../figure/macro.njk" import appFigure -%}
+{%- from "../figure/macro.njk" import appFigure with context -%}
 <ul class="app-gallery">
 {% for item in params.items %}
   {% set id = item.id or (item.text | slug) %}

--- a/app/_components/image/template.njk
+++ b/app/_components/image/template.njk
@@ -1,3 +1,4 @@
-<a href="{{ params.path }}/{{ params.file }}">
-  <img src="{{ params.path | replace('images', 'image/480') }}/{{ file }}" srcset="{{ params.path | replace('images', 'image/480') }}/{{ params.file }} 480w, {{ params.path | replace('images', 'image/960') }}/{{ params.file }} 960w" alt="{{ params.alt }}">
+{% set path = params.path if params.path else page.filePathStem | replace("/posts", "/images") %}
+<a href="{{ path }}/{{ params.file }}">
+  <img src="{{ path | replace('images', 'image/480') }}/{{ file }}" srcset="{{ path | replace('images', 'image/480') }}/{{ params.file }} 480w, {{ path | replace('images', 'image/960') }}/{{ params.file }} 960w" alt="{{ params.alt }}">
 </a>

--- a/app/posts/apply-for-teacher-training/2019-02-17-apply-april-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-17-apply-april-2018.md
@@ -19,9 +19,8 @@ One of the options for private beta is to use UCAS as the back end for our servi
 
 ### Application
 
-{% from "image/macro.njk" import appImage %}
+{% from "image/macro.njk" import appImage with context %}
 {{ appImage({
-  path: page.filePathStem | replace("/posts", "/images"),
   file: "application.png",
   alt: "Screenshot of Application"
 }) }}
@@ -37,7 +36,6 @@ One of the options for private beta is to use UCAS as the back end for our servi
 ### Application summary (full)
 
 {{ appImage({
-  path: page.filePathStem | replace("/posts", "/images"),
   file: "application-summary-full.png",
   alt: "Screenshot of Application summary (full)"
 }) }}
@@ -57,7 +55,6 @@ This will be maximum a set of data the providers would need to know in an applic
 ### Application summary (reduced)
 
 {{ appImage({
-  path: page.filePathStem | replace("/posts", "/images"),
   file: "application-summary-reduced.png",
   alt: "Screenshot of Application summary (reduced)"
 }) }}

--- a/app/posts/apply-for-teacher-training/2019-02-17-apply-may-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-17-apply-may-2018.md
@@ -25,9 +25,8 @@ One of the options for private beta is to use UCAS as the back end for our servi
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Your application"},
     {text: "Personal details"},

--- a/app/posts/apply-for-teacher-training/2019-02-19-apply-august-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-19-apply-august-2018.md
@@ -19,9 +19,8 @@ Our designer Vin documented these on [Confluence](https://dfedigital.atlassian.n
 >
 > Yet to be tested.
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Your application"},
     {text: "Personal details"},

--- a/app/posts/apply-for-teacher-training/2019-02-19-apply-december-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-19-apply-december-2018.md
@@ -12,9 +12,8 @@ tags: apply-for-teacher-training
 ---
 Our designer Faz looked at capturing the same fields needed in the UCAS process but by using the GOV.UK design patterns.
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Apply landing page"},
     {text: "Create an account"},

--- a/app/posts/apply-for-teacher-training/2019-02-20-free-form-application.md
+++ b/app/posts/apply-for-teacher-training/2019-02-20-free-form-application.md
@@ -26,9 +26,8 @@ Candidates want to express more about themselves than just giving mandatory data
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Your application"},
     {text: "Personal details"},

--- a/app/posts/apply-for-teacher-training/2019-02-20-progressive-application.md
+++ b/app/posts/apply-for-teacher-training/2019-02-20-progressive-application.md
@@ -18,9 +18,8 @@ A user flow where a candidate creates an application in bits as and when require
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Your application"},
     {text: "Your application (expanded)"},

--- a/app/posts/apply-for-teacher-training/2019-08-16-magic-link-login.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-magic-link-login.md
@@ -13,9 +13,8 @@ Users had trouble with accounts:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Start page"},
     {text: "Before you begin"},

--- a/app/posts/apply-for-teacher-training/2019-08-16-pick-a-course.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-pick-a-course.md
@@ -15,9 +15,8 @@ Users coming directly from Find could have a course pre-populated or added using
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Your application"},
     {text: "Have you chosen a course to apply to?"},

--- a/app/posts/apply-for-teacher-training/2019-08-16-submitted-application.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-submitted-application.md
@@ -9,9 +9,8 @@ Candidates may also need to start a new application, or see what they originally
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Applications"},
     {text: "Submitted application"}

--- a/app/posts/apply-for-teacher-training/2019-08-16-work-history.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-work-history.md
@@ -7,9 +7,8 @@ Following on from [the original design](/apply-june-2019/work-history), rather t
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Work history"},
     {text: "Job"},

--- a/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
+++ b/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
@@ -34,9 +34,8 @@ This alternative creates a simpler application process that is also easier to bu
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Application with courses"},
     {text: "Old dashboard"},

--- a/app/posts/apply-for-teacher-training/2019-09-04-cover-letters.md
+++ b/app/posts/apply-for-teacher-training/2019-09-04-cover-letters.md
@@ -20,9 +20,8 @@ Base cover letters on the name of the provider. If there’s multiple courses fo
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Your application"},
     {text: "Cover letter"},

--- a/app/posts/apply-for-teacher-training/2019-09-18-equality-monitoring.md
+++ b/app/posts/apply-for-teacher-training/2019-09-18-equality-monitoring.md
@@ -63,9 +63,8 @@ The design system provides a [complete pattern for collecting ethnicity informat
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Equality monitoring"},
     {text: "What is your sex?"},

--- a/app/posts/apply-for-teacher-training/2019-09-18-undergraduate-degree.md
+++ b/app/posts/apply-for-teacher-training/2019-09-18-undergraduate-degree.md
@@ -15,9 +15,8 @@ This design iteration asks for the undergraduate degree first, and includes a pr
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Add undergraduate degree"},
     {text: "Add another degree"},

--- a/app/posts/apply-for-teacher-training/2019-10-15-apply-september-2019.md
+++ b/app/posts/apply-for-teacher-training/2019-10-15-apply-september-2019.md
@@ -3,9 +3,8 @@ title: Apply – September 2019
 description: A full set of screens showing the design in mid-September.
 tags: apply-for-teacher-training
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Your application"},
     {text: "Have you chosen a course to apply to"},

--- a/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
+++ b/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
@@ -28,9 +28,8 @@ To skip the start page, the content on the Apply and Find start pages must be co
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Choose how to apply"},
     {text: "Check you can use GOV.UK Apply"},

--- a/app/posts/apply-for-teacher-training/2019-10-25-amend-withdraw.md
+++ b/app/posts/apply-for-teacher-training/2019-10-25-amend-withdraw.md
@@ -25,9 +25,8 @@ The business logic dictates that a candidate has 5 working days after submitting
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [{
     id: "dashboard-submitted",
     text: "Dashboard post submission (within amendment period)"

--- a/app/posts/apply-for-teacher-training/2019-11-29-apply-launch.md
+++ b/app/posts/apply-for-teacher-training/2019-11-29-apply-launch.md
@@ -23,9 +23,8 @@ On 26 November 2019 we launched the initial Apply pilot with one provider, Royal
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [{
     text: "Start page",
     id: "01-start-page"

--- a/app/posts/apply-for-teacher-training/2019-12-05-give-a-reference.md
+++ b/app/posts/apply-for-teacher-training/2019-12-05-give-a-reference.md
@@ -19,9 +19,8 @@ It’ll probably use a token and behave similarly to the magic link we send for 
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [{
     text: "Start page",
     caption: "We ask referees if they are happy to give a reference. If they select no, a free text area allows them to provide a reason."

--- a/app/posts/apply-for-teacher-training/2019-12-06-training-with-a-disability.md
+++ b/app/posts/apply-for-teacher-training/2019-12-06-training-with-a-disability.md
@@ -43,9 +43,8 @@ Essentially, we can ask questions if it’s regarding an applicant’s ability t
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Training with a disability"},
     {text: "Review when disability given"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/academic-qualifications.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/academic-qualifications.md
@@ -2,9 +2,8 @@
 title: Academic qualifications
 description: Adding your degree, statutory requirements and other qualifications
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Academic qualifications"},
     {text: "Your degree"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/contact-details.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/contact-details.md
@@ -2,9 +2,8 @@
 title: Contact details
 description: Adding emails, phone number and address
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Contact details"},
     {text: "What is your address"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/create-account.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/create-account.md
@@ -2,9 +2,8 @@
 title: Create account
 description: Sign up, sign in, recover password and dashboard
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Start page"},
     {text: "Create an account"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/language-skills.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/language-skills.md
@@ -2,9 +2,8 @@
 title: Language skills
 description: Is English your main language?
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "English is main language"},
     {text: "English is not main language"}

--- a/app/posts/apply-for-teacher-training/apply-june-2019/personal-details.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/personal-details.md
@@ -2,9 +2,8 @@
 title: Personal details
 description: Adding name, nationality and visas
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Dashboard"},
     {text: "Personal teaching profile"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/references.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/references.md
@@ -2,9 +2,8 @@
 title: References
 description: Adding first and second referees
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Add first referee"},
     {text: "Add second referee"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/review-and-submit.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/review-and-submit.md
@@ -2,9 +2,8 @@
 title: Review and submit
 description: See what you’ve entered, interview preferences and submission
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Review application"},
     {text: "Interview preferences"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/school-experience.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/school-experience.md
@@ -2,9 +2,8 @@
 title: School experience
 description: Adding school experience roles
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "School experience"},
     {text: "Add role"},

--- a/app/posts/apply-for-teacher-training/apply-june-2019/subject-knowledge.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/subject-knowledge.md
@@ -2,9 +2,8 @@
 title: Subject knowledge
 description: Evidence of knowledge and interest in a subject
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Subject knowledge"}
   ]

--- a/app/posts/apply-for-teacher-training/apply-june-2019/vocation.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/vocation.md
@@ -2,9 +2,8 @@
 title: Why you want to be a teacher?
 description: Also known as vocation
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Why you want to be a teacher?"}
   ]

--- a/app/posts/apply-for-teacher-training/apply-june-2019/work-history.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/work-history.md
@@ -2,9 +2,8 @@
 title: Work history
 description: Adding work history and explaining gaps
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Work history"},
     {text: "5 year gap"},

--- a/app/posts/apply-for-teacher-training/ucas/application.md
+++ b/app/posts/apply-for-teacher-training/ucas/application.md
@@ -2,9 +2,8 @@
 title: Application form
 description: Completing the UCAS application form
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     { text: "Welcome to UCAS teacher training"},
     { text: "Personal details"},

--- a/app/posts/apply-for-teacher-training/ucas/references.md
+++ b/app/posts/apply-for-teacher-training/ucas/references.md
@@ -2,9 +2,8 @@
 title: References
 description: Completing a reference for a UCAS applicant
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Referee giving reference"},
     {text: "Referee giving their details"},

--- a/app/posts/apply-for-teacher-training/ucas/sign-up.md
+++ b/app/posts/apply-for-teacher-training/ucas/sign-up.md
@@ -2,9 +2,8 @@
 title: Sign up
 description: Registering for UCAS Teacher Training
 ---
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Welcome"},
     {text: "Terms and conditions"},

--- a/app/posts/find-teacher-training/2019-03-01-performance-march-2019.md
+++ b/app/posts/find-teacher-training/2019-03-01-performance-march-2019.md
@@ -28,10 +28,9 @@ You can [see the live report in our dashboard](https://datastudio.google.com/ope
 
 ## Service overview
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "service-overview.png"
   }
 }) }}
@@ -48,7 +47,6 @@ The average user who finds a course page will visit at least 4 pages on the serv
 
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "success-measures.png"
   }
 }) }}

--- a/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
+++ b/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
@@ -25,9 +25,8 @@ This design increased bounce rate on the page from 8% to 18% in the first weeks 
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Courses starting in different years"},
     {text: "Iteration showing closing dates"}

--- a/app/posts/find-teacher-training/2019-09-10-end-of-cycle.md
+++ b/app/posts/find-teacher-training/2019-09-10-end-of-cycle.md
@@ -7,10 +7,9 @@ A follow-up to our original [end of cycle notice](/find-teacher-training/end-of-
 
 It is confusing to allow users to search for courses in the current cycle. Find returns a small set of courses that haven’t been filled, this will mislead candidates about their options for 2020/21. It is not clear that results shown are just for 2019/20.
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "course-search-disabled.png"
   },
   caption: "Course search disabled page"

--- a/app/posts/find-teacher-training/2019-12-06-find-december-2019.md
+++ b/app/posts/find-teacher-training/2019-12-06-find-december-2019.md
@@ -22,9 +22,8 @@ Iteration on Find has been minimal in the last year because the team has needed 
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "GOV.UK Start page"},
     {text: "Search by location" },

--- a/app/posts/manage-teacher-training-applications/2019-02-19-first-designs.md
+++ b/app/posts/manage-teacher-training-applications/2019-02-19-first-designs.md
@@ -19,9 +19,8 @@ The applciations themselves are tagged to various statuses that the admins can u
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace('/posts', '/images'),
   items: [
     {text: "Dashboard"},
     {text: "New applications"},

--- a/app/posts/manage-teacher-training-applications/2019-02-21-fewer-statuses.md
+++ b/app/posts/manage-teacher-training-applications/2019-02-21-fewer-statuses.md
@@ -28,9 +28,8 @@ The team thought the statuses were not relevant so came up with a minimal set of
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Dashboard"},
     {text: "New applications"},

--- a/app/posts/manage-teacher-training-applications/2019-09-04-august-2019.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-04-august-2019.md
@@ -15,9 +15,8 @@ An update on the [2018 prototype](/manage-teacher-training-applications/better-s
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Applications"},
     {text: "New applications"},

--- a/app/posts/manage-teacher-training-applications/2019-09-18-application-states.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-18-application-states.md
@@ -54,9 +54,8 @@ An unconditional offer (which would be ‘Accepted (unconditional)’) goes stra
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Applications"},
     {text: "New applications"},

--- a/app/posts/manage-teacher-training-applications/2019-09-18-make-an-offer.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-18-make-an-offer.md
@@ -13,9 +13,8 @@ This design presents a list of boxes to prompt conversation about what might go 
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Change status"},
     {text: "Make an offer"}

--- a/app/posts/manage-teacher-training-applications/2019-10-15-minimal-ui.md
+++ b/app/posts/manage-teacher-training-applications/2019-10-15-minimal-ui.md
@@ -56,9 +56,8 @@ With this in mind, we consolidated the two offer types into one, allowing provid
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Applications"},
     {text: "Application"},

--- a/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
@@ -48,9 +48,8 @@ If the course is marked as a special educational needs one, it’s appended to t
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Type of course"},
     {text: "Pick a subject"},

--- a/app/posts/publish-teacher-training-courses/2018-12-15-new-course-2.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-15-new-course-2.md
@@ -48,9 +48,8 @@ University of Wolverhampton said, [“Ours are all modular … we have 6x 20 cre
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Organisation page"},
     {text: "Type of course"},

--- a/app/posts/publish-teacher-training-courses/2018-12-16-new-course-locations.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-16-new-course-locations.md
@@ -15,9 +15,8 @@ On the training locations list, if ‘full time or part time’ is chosen, then 
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Training locations"},
     {text: "For a full or part time course"},

--- a/app/posts/publish-teacher-training-courses/2018-12-17-specific-requirements.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-17-specific-requirements.md
@@ -109,9 +109,8 @@ This option accepts all applicants, even if they have grades below a C.
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Example warnings in UCAS apply"},
     {text: "Qualification options in UCAS"},

--- a/app/posts/publish-teacher-training-courses/2018-12-18-minimum-course-requirements.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-18-minimum-course-requirements.md
@@ -20,10 +20,9 @@ Things not yet considered in this design:
 
 > Providers should look for further evidence of a breadth of achievement in English where applicants have achieved a GCSE grade 4 or above in English literature only.
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "minimum-course-requirements.png"
   },
   caption: "Minimum course requirements"

--- a/app/posts/publish-teacher-training-courses/2018-12-19-edit-title.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-19-edit-title.md
@@ -16,9 +16,8 @@ We tested this with the last user in our ‘New course wizard’ round of resear
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Course title is ok"},
     {text: "Course title needs changes"}

--- a/app/posts/publish-teacher-training-courses/2018-12-20-publish-states.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-20-publish-states.md
@@ -13,10 +13,9 @@ You could write and publish content for new courses on Publish, they’d be labe
 * [Suffolk and Norfolk Primary SCITT](https://lookback.io/watch/ud8KczRqKKAexox28)
 * [The Downland Alliance](https://lookback.io/watch/E8MxZYHrmy7E7q85w)
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "courses-quiz.png"
   }
 }) }}

--- a/app/posts/publish-teacher-training-courses/2018-12-21-vacancies.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-21-vacancies.md
@@ -31,9 +31,8 @@ When we tried removing the message about the UCAS Apply delay it wasn’t clear 
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Organisation table showing link to edit vacancies"},
     {text: "Multiple training locations"},

--- a/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
@@ -43,9 +43,8 @@ The new design:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Published course"},
     {text: "Published with unpublished changes"},

--- a/app/posts/publish-teacher-training-courses/2019-01-14-new-course-iteration-14-jan.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-14-new-course-iteration-14-jan.md
@@ -14,9 +14,8 @@ In this iteration we changed:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "What type of course?"},
     {text: "Pick a subject"},

--- a/app/posts/publish-teacher-training-courses/2019-01-14-vacancies-iteration-14-jan.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-14-vacancies-iteration-14-jan.md
@@ -15,9 +15,8 @@ In this design we:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Close course (one training location)"},
     {text: "Open course (one training location)"},

--- a/app/posts/publish-teacher-training-courses/2019-01-28-new-further-education-course.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-28-new-further-education-course.md
@@ -59,9 +59,8 @@ As courses aren’t tied to allocations, the opening date for applications is ar
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "What type of course?"},
     {text: "What is the course title?"},

--- a/app/posts/publish-teacher-training-courses/2019-01-30-preparing-for-locations.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-30-preparing-for-locations.md
@@ -17,9 +17,8 @@ We’re also testing a space for guidance in the right hand column
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Organisation"},
     {text: "Courses"},

--- a/app/posts/publish-teacher-training-courses/2019-01-31-new-training-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-31-new-training-location.md
@@ -41,9 +41,8 @@ On the summary screens we started with ‘Code’, which a user misunderstood. W
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Training locations"},
     {text: "What type of training location?"},

--- a/app/posts/publish-teacher-training-courses/2019-02-11-new-training-location-region.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-11-new-training-location-region.md
@@ -26,9 +26,8 @@ Concerns we expect from providers that the design would need to address:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "What type of location?"},
     {text: "Region name"},

--- a/app/posts/publish-teacher-training-courses/2019-02-12-mvp-add-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-12-mvp-add-location.md
@@ -11,9 +11,8 @@ We’d also avoid having to categorise existing locations into types, though doi
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Add training location"},
     {text: "Edit training location"},

--- a/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
@@ -13,9 +13,8 @@ Update the design so that:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Who is the accredited body?"},
     {text: "When there are no previous accredited bodies"},

--- a/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
@@ -16,9 +16,8 @@ The original design only catered for the dominant use case. For MVP we can ask f
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Pick the languages for this course"},
     {text: "Original design"}

--- a/app/posts/publish-teacher-training-courses/2019-02-16-rollover-reckons.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-16-rollover-reckons.md
@@ -43,9 +43,8 @@ While there are two cycles, providers need to easily manage courses and location
 
 ## First designs
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Start rollover"},
     {text: "Pick which courses"},

--- a/app/posts/publish-teacher-training-courses/2019-02-17-mvp-add-location-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-17-mvp-add-location-iteration.md
@@ -20,9 +20,8 @@ Success messages after saving and edited have been added, these reinforce the me
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Organisation"},
     {text: "Locations"},

--- a/app/posts/publish-teacher-training-courses/2019-02-21-rollover-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-21-rollover-wizard.md
@@ -50,9 +50,8 @@ We would need to think of another way to encourage providers to review and fix t
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Organisation with rollover prompt"},
     {text: "Start rollover"},

--- a/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
@@ -54,9 +54,8 @@ It’s not clear whether we will have time to build an onboarding wizard, as MVP
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Accept terms"},
     {text: "Organisation name"},

--- a/app/posts/publish-teacher-training-courses/2019-02-27-ucas-apply-preferences.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-27-ucas-apply-preferences.md
@@ -192,10 +192,9 @@ We indicate the difference in letters to new providers and ask for their choice.
 
 * * *
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "ucas-apply-preferences.png"
   },
   caption: "UCAS Apply preferences"

--- a/app/posts/publish-teacher-training-courses/2019-03-01-ucas-apply-preferences-2.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-01-ucas-apply-preferences-2.md
@@ -38,9 +38,8 @@ For this to propagate to UCAS it needs to be sent through as the email for the U
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     { text: "Organisation"},
     { text: "UCAS Apply preferences"},

--- a/app/posts/publish-teacher-training-courses/2019-03-05-onboarding-wizard-as-google-form.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-05-onboarding-wizard-as-google-form.md
@@ -7,9 +7,8 @@ An update on the [original onboarding wizard](/publish-teacher-training-courses/
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Who is adding this organisation?"},
     {text: "Organisation name"},

--- a/app/posts/publish-teacher-training-courses/2019-03-05-transition-explainer.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-05-transition-explainer.md
@@ -12,10 +12,9 @@ We need to make it clear to all users that they must:
 
 We’re doing this with a page they’ll see when they first log in, much like the [‘Before you begin’ terms and conditions page](/publish-teacher-training-courses/terms-agreement). After seeing it once it won’t be shown to them again.
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "when-an-organisation-is-transitioned.png"
   },
   caption: "A page transitioned organisations will see when they first log in"

--- a/app/posts/publish-teacher-training-courses/2019-03-08-deleting-and-withdrawing.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-08-deleting-and-withdrawing.md
@@ -19,9 +19,8 @@ We need to test these assumptions with users.
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Course that can be deleted"},
     {text: "Delete this course"},

--- a/app/posts/publish-teacher-training-courses/2019-03-08-ucas-contacts.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-08-ucas-contacts.md
@@ -48,9 +48,8 @@ The GT12 reply to contact is captured when users edit their letter template.
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "UCAS Apply settings"},
     {text: "UTT Correspondent"},

--- a/app/posts/publish-teacher-training-courses/2019-03-15-requesting-a-title.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-15-requesting-a-title.md
@@ -5,9 +5,8 @@ tags: publish-teacher-training-courses
 ---
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [{
     text: "Confirming a course with requested title",
     caption: "This shows a ‘requested title’, which is also shown in the preview. We probably also need to include the current title somewhere."

--- a/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
@@ -17,9 +17,8 @@ By splitting the page into tabs we:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "An unpublished course"},
     {text: "An unpublished course – Edit course details"},
@@ -32,7 +31,7 @@ By splitting the page into tabs we:
 
 ## Old course design
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
     path: "/images/publish-teacher-training-courses/deleting-and-withdrawing",

--- a/app/posts/publish-teacher-training-courses/2019-03-25-age-ranges.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-25-age-ranges.md
@@ -23,9 +23,8 @@ We can’t easily map existing UCAS data to age range. We should ask for it agai
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Primary age ranges"},
     {text: "Secondary age ranges"}

--- a/app/posts/publish-teacher-training-courses/2019-03-26-new-location-google-form.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-26-new-location-google-form.md
@@ -9,9 +9,8 @@ As an MVP, and so that providers can still add locations when they need to, weâ€
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Locations with link to Google form"},
     {text: "Who is adding?"},

--- a/app/posts/publish-teacher-training-courses/2019-04-02-first-transition-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-02-first-transition-mvp.md
@@ -21,9 +21,8 @@ The course tabs shown below are also illustrative and may not be ready.
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Transition screen"},
     {text: "Organisation page with locations"},

--- a/app/posts/publish-teacher-training-courses/2019-04-05-email-video-comms.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-05-email-video-comms.md
@@ -30,7 +30,7 @@ Becoming a Teacher team
   content: videoContent
 }) }}
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   embed: {
     youtubeId: "nxmtXGy1cCY",
@@ -41,7 +41,6 @@ Becoming a Teacher team
 
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "guidance-for-publish-teacher-training-courses.png"
   },
   caption: "Guidance page with video"

--- a/app/posts/publish-teacher-training-courses/2019-04-09-minimum-requirements-iterations.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-09-minimum-requirements-iterations.md
@@ -15,7 +15,7 @@ Progression of the minimum requirements page design:
 
 ## Screenshots
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
     path: "/images/publish-teacher-training-courses/new-course-wizard-iteration",
@@ -32,9 +32,8 @@ Progression of the minimum requirements page design:
   caption: "Question 2: Tests for candidates without GCSE requirements"
 }) }}
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Two questions"},
     {text: "Options in a table"},

--- a/app/posts/publish-teacher-training-courses/2019-04-09-new-course-wizard-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-09-new-course-wizard-iteration.md
@@ -11,9 +11,8 @@ Bring the wizard in line with changes made to the Google Form:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Is this a teaching apprenticeship?"},
     {text: "When will applications open?"},

--- a/app/posts/publish-teacher-training-courses/2019-04-15-mvp-type-of-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-mvp-type-of-location.md
@@ -13,10 +13,9 @@ In the design below, if a user selects ‘An area’, then we would validate dif
 
 A [more complete workflow was previously designed and tested](/publish-teacher-training-courses/new-training-location-region).
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "type-of-location.png"
   },
   caption: "Type of location"

--- a/app/posts/publish-teacher-training-courses/2019-04-15-problems-with-course.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-problems-with-course.md
@@ -21,9 +21,8 @@ Specifically we want to:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "We’ve found problems with this course"},
     {text: "Problems with this course"}

--- a/app/posts/publish-teacher-training-courses/2019-04-15-tabs-on-locations.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-tabs-on-locations.md
@@ -9,9 +9,8 @@ This design adds tabs, [like on courses](/publish-teacher-training-courses/cours
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Courses at each location"},
     {text: "Edit location"},

--- a/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
@@ -40,7 +40,7 @@ A user can select Yes to equivalency tests but can restrict this by subject (see
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
   path: "/images/publish-teacher-training-courses/new-course-wizard-iteration",
   items: [

--- a/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
@@ -45,9 +45,8 @@ Further education screens are probably out of scope for MVP.
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Level and SEND"},
     {text: "Subject"},

--- a/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
@@ -76,9 +76,8 @@ The preview links could persist on the course page and not be dependent on the c
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Courses for next cycle"},
     {text: "Draft course with publish messaging"},

--- a/app/posts/publish-teacher-training-courses/2019-05-14-shipped-for-transition.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-14-shipped-for-transition.md
@@ -39,9 +39,8 @@ Some providers have been using the add course form to try and edit existing cour
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Transition information"},
     {text: "Organisation"},

--- a/app/posts/publish-teacher-training-courses/2019-05-20-support-for-missing-features.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-20-support-for-missing-features.md
@@ -23,9 +23,8 @@ In the design below we add a call to action where the feature would be – ‘Re
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Get support and guidance"},
     {text: "Request a change"},

--- a/app/posts/publish-teacher-training-courses/2019-05-22-courses-as-an-accredited-body.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-22-courses-as-an-accredited-body.md
@@ -52,9 +52,8 @@ The practice recommended by UCAS of discontinuing a course and creating a new on
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Organisation page with new section"},
     {text: "Courses as an accredited body"},

--- a/app/posts/publish-teacher-training-courses/2019-05-31-access-to-multiple-organisations.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-31-access-to-multiple-organisations.md
@@ -14,10 +14,9 @@ We discovered this while researching with accredited bodies: [Research video](ht
 
 This should also simplify the logic for the current systems.
 
-{% from "figure/macro.njk" import appFigure %}
+{% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: page.filePathStem | replace("/posts", "/images"),
     file: "organisations.png"
   },
   caption: "Organisations page"

--- a/app/posts/publish-teacher-training-courses/2019-06-10-minimum-requirements-read-only-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2019-06-10-minimum-requirements-read-only-mvp.md
@@ -11,9 +11,8 @@ To ship the read-only version of this feature earlier we updated the design. It 
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Code 1 – Must have"},
     {text: "Code 2 – Taking"},

--- a/app/posts/publish-teacher-training-courses/2019-08-06-allocations.md
+++ b/app/posts/publish-teacher-training-courses/2019-08-06-allocations.md
@@ -31,9 +31,8 @@ The link text, ‘request allocations’ might need to refer to ‘permission to
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Allocations for a course"},
     {text: "Allocations for a fee-funded PE course"}

--- a/app/posts/publish-teacher-training-courses/2019-10-15-what-we-did-for-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2019-10-15-what-we-did-for-rollover.md
@@ -60,9 +60,8 @@ When the cycle opens, the cycle is marked as open ([Pull request](https://github
 
 ## How this looked
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: "Before rollover period"},
     {text: "During rollover period"},

--- a/app/posts/support-for-apply/2019-11-29-prototype-v1.md
+++ b/app/posts/support-for-apply/2019-11-29-prototype-v1.md
@@ -21,9 +21,8 @@ In future we’ll look at:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [
     {text: 'Application list'},
     {text: 'Application details (1 reference request failed and waiting on 1 reference)'},

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -78,9 +78,8 @@ tags:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [`;
 
   const templateEnd = `

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -110,9 +110,8 @@ tags:
 
 ## Screenshots
 
-{% from "gallery/macro.njk" import appGallery %}
+{% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({
-  path: page.filePathStem | replace("/posts", "/images"),
   items: [`;
 
   const templateEnd = `


### PR DESCRIPTION
- Make `page` available on the image macro
- Remove the need to reuse the same path manipulation logic in every post
- Simplify syntax in posts