### PR TITLE
Organise content to allow use of default tags in folder data

### DIFF
--- a/app/collections/apply-for-teacher-training.md
+++ b/app/collections/apply-for-teacher-training.md
@@ -1,7 +1,9 @@
 ---
-layout: collection
 title: Apply for teacher training
 description: A service for candidates to submit an application to their chosen teacher training courses
+breadcrumbs:
+  text: Apply for teacher training
+  href: /apply-for-teacher-training
 related:
   items:
   - text: Prototype
@@ -10,6 +12,5 @@ related:
       Password: `bat`
     href: https://apply-beta-prototype.herokuapp.com/
 collection: apply-for-teacher-training
-tags: product
 order: 3
 ---

--- a/app/collections/collections.json
+++ b/app/collections/collections.json
@@ -1,0 +1,7 @@
+{
+  "layout": "collection",
+  "permalink": "{{ page.filePathStem | replace('collections/', '') }}/index.html",
+  "tags": [
+    "product"
+  ]
+}

--- a/app/collections/find-teacher-training.md
+++ b/app/collections/find-teacher-training.md
@@ -1,12 +1,13 @@
 ---
-layout: collection
 title: Find postgraduate teacher training
 description: A service for candidates to find courses by location, provider or subject
 related:
   items:
   - text: Prototype
     href: https://search-and-compare-prototype.herokuapp.com/
+breadcrumbs:
+  text: Find postgraduate teacher training
+  href: /find-teacher-training
 collection: find-teacher-training
-tags: product
 order: 1
 ---

--- a/app/collections/manage-teacher-training-applications.md
+++ b/app/collections/manage-teacher-training-applications.md
@@ -1,5 +1,4 @@
 ---
-layout: collection
 title: Manage teacher training applications
 description: A service for training providers to see, manage and make decisions on applications they receive
 related:
@@ -9,7 +8,9 @@ related:
       Username: `apply`
       Password: `bat`
     href: https://manage-teacher-training-applications-beta.herokuapp.com/
+breadcrumbs:
+  text: Manage teacher training applications
+  href: /manage-teacher-training-applications
 collection: manage-teacher-training-applications
-tags: product
 order: 4
 ---

--- a/app/collections/publish-teacher-training-courses.md
+++ b/app/collections/publish-teacher-training-courses.md
@@ -1,12 +1,13 @@
 ---
-layout: collection
 title: Publish teacher training courses
 description: A service for training providers to publish and manage their courses
 related:
   items:
   - text: Prototype
     href: https://manage-courses-prototype.herokuapp.com
+breadcrumbs:
+  text: Publish teacher training courses
+  href: /publish-teacher-training-courses
 collection: publish-teacher-training-courses
-tags: product
 order: 2
 ---

--- a/app/collections/support-for-apply.md
+++ b/app/collections/support-for-apply.md
@@ -1,5 +1,4 @@
 ---
-layout: collection
 title: Support for Apply
 description: A tool for support agents to manage the Apply for teacher training service
 related:
@@ -9,7 +8,9 @@ related:
       Username: `apply`
       Password: `bat`
     href: https://support-for-apply-prototype.herokuapp.com
+breadcrumbs:
+  text: Support for Apply
+  href: /support-for-apply
 collection: support-for-apply
-tags: product
 order: 5
 ---

--- a/app/posts/apply-for-teacher-training/2019-02-17-apply-april-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-17-apply-april-2018.md
@@ -5,7 +5,6 @@ related:
   items:
   - text: Prototype
     href: https://bat-apply.herokuapp.com/v01/application
-tags: apply-for-teacher-training
 ---
 Our designer Vin documented these on [Confluence](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/279314433/Designs).
 

--- a/app/posts/apply-for-teacher-training/2019-02-17-apply-may-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-17-apply-may-2018.md
@@ -5,7 +5,6 @@ related:
   items:
   - text: Prototype
     href: https://bat-apply.herokuapp.com/v02/application
-tags: apply-for-teacher-training
 ---
 Our designer Vin documented these on [Confluence](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/279314433/Designs).
 

--- a/app/posts/apply-for-teacher-training/2019-02-19-apply-august-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-19-apply-august-2018.md
@@ -7,7 +7,6 @@ related:
     href: https://bat-manage-teacher-training-applications.herokuapp.com/candidate/v05/
   - text: GitHub
     href: https://github.com/DFE-Digital/manage-teacher-training-applications/tree/master/app/views/candidate/v05
-tags: apply-for-teacher-training
 ---
 Our designer Vin documented these on [Confluence](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/279314433/Designs):
 

--- a/app/posts/apply-for-teacher-training/2019-02-19-apply-december-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-19-apply-december-2018.md
@@ -8,7 +8,6 @@ related:
       Username: `batapply`
       Password: `batapply1`
     href: https://bat-apply-prototype.herokuapp.com
-tags: apply-for-teacher-training
 ---
 Our designer Faz looked at capturing the same fields needed in the UCAS process but by using the GOV.UK design patterns.
 

--- a/app/posts/apply-for-teacher-training/2019-02-20-free-form-application.md
+++ b/app/posts/apply-for-teacher-training/2019-02-20-free-form-application.md
@@ -5,7 +5,6 @@ related:
   items:
   - text: Prototype
     href: https://bat-apply.herokuapp.com/v04_2/application/index
-tags: apply-for-teacher-training
 ---
 Our designer Vin documented these on [Confluence](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/279314433/Designs) (Project Bluesky).
 

--- a/app/posts/apply-for-teacher-training/2019-02-20-progressive-application.md
+++ b/app/posts/apply-for-teacher-training/2019-02-20-progressive-application.md
@@ -1,7 +1,6 @@
 ---
 title: Progressive application
 description: Ask for further information only when needed.
-tags: apply-for-teacher-training
 ---
 Our designer Vin documented these on [Confluence](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/279314433/Designs) (Project Bluesky).
 

--- a/app/posts/apply-for-teacher-training/2019-05-02-paper-based-application.md
+++ b/app/posts/apply-for-teacher-training/2019-05-02-paper-based-application.md
@@ -1,7 +1,6 @@
 ---
 title: Prototyping with paper-based application forms
 description: Testing hypotheses and preparing for a concierged service.
-tags: apply-for-teacher-training
 ---
 Before building a fully DfE operated apply service, we wanted to test certain elements of an end-to-end minimum viable product. We began with a series of hypotheses, two of which related to the design of the application form and the information given to providers. These hypotheses were:
 

--- a/app/posts/apply-for-teacher-training/2019-08-01-beta-version-1.md
+++ b/app/posts/apply-for-teacher-training/2019-08-01-beta-version-1.md
@@ -10,7 +10,6 @@ related:
     href: https://apply-beta-prototype-v1.herokuapp.com
   - text: Findings and recommendations from usability testing
     href: https://docs.google.com/presentation/d/11n2OsN9LswmHab64FG0sIsQ-BijdS-GM
-tags: apply-for-teacher-training
 ---
 In June the Apply team started development of the candidate-facing aspects of the service. To ensure that what we are delivering is usable and understandable, we created an interactive prototype that we could use to test with users and validate our design decisions.
 

--- a/app/posts/apply-for-teacher-training/2019-08-16-magic-link-login.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-magic-link-login.md
@@ -1,7 +1,6 @@
 ---
 title: Sign up and log in using a magic link
 description: An alternative to using an account and password.
-tags: apply-for-teacher-training
 ---
 An alternative to the [account and password design](/apply-for-teacher-training/apply-june-2019/create-account).
 

--- a/app/posts/apply-for-teacher-training/2019-08-16-pick-a-course.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-pick-a-course.md
@@ -1,7 +1,6 @@
 ---
 title: Picking courses to apply to
 description: Providing a route to Find, or selecting the course you want.
-tags: apply-for-teacher-training
 ---
 Candidates using Apply need to choose a course to apply to.
 

--- a/app/posts/apply-for-teacher-training/2019-08-16-submitted-application.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-submitted-application.md
@@ -1,7 +1,6 @@
 ---
 title: Submitted application
 description: Applications page and read only view.
-tags: apply-for-teacher-training
 ---
 Once a user has submitted at least one application, when they return to Apply the first thing they should see is their application status.
 

--- a/app/posts/apply-for-teacher-training/2019-08-16-work-history.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-work-history.md
@@ -1,7 +1,6 @@
 ---
 title: Work history (August iteration)
 description: Move guidance into a question.
-tags: apply-for-teacher-training
 ---
 Following on from [the original design](/apply-june-2019/work-history), rather than using multiple details elements and two submit button we’ve shaped the guidance as a question and used routing based on their answer to send users to the right place.
 

--- a/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
+++ b/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
@@ -1,7 +1,6 @@
 ---
 title: Removing the teaching profile
 description: Why we removed it, and the alternative.
-tags: apply-for-teacher-training
 ---
 [In the July 2019 prototype](https://apply-beta-prototype-v1.herokuapp.com/) ([screenshots](/apply-for-teacher-training/apply-june-2019/personal-details)) we tested a version of the application where course choice was separated from your teaching profile. Your teaching profile was a shareable or reusable profile that would be pulled into each application.
 

--- a/app/posts/apply-for-teacher-training/2019-09-04-cover-letters.md
+++ b/app/posts/apply-for-teacher-training/2019-09-04-cover-letters.md
@@ -5,7 +5,6 @@ related:
   items:
   - text: Trello ticket
     href: https://trello.com/c/spYyD6s6
-tags: apply-for-teacher-training
 ---
 Subject knowledge as a single field presents problems if you’re applying to multiple subjects across different courses, for example Physics as well as Mathematics. You couldn’t tailor one field to both subjects, this also applies if someone applies to both primary and secondary courses, although this is less likely.
 

--- a/app/posts/apply-for-teacher-training/2019-09-18-equality-monitoring.md
+++ b/app/posts/apply-for-teacher-training/2019-09-18-equality-monitoring.md
@@ -15,7 +15,6 @@ related:
     href: https://docs.google.com/spreadsheets/d/1uY6ZzQePVoWgIzrdRKtuinj9NzQ5dgwaL6DMIYFUH_c
   - text: Trello ticket
     href: https://trello.com/c/ztd2hNAH
-tags: apply-for-teacher-training
 ---
 Our first pass at asking for personal information for the purposes of monitoring equality.
 

--- a/app/posts/apply-for-teacher-training/2019-09-18-undergraduate-degree.md
+++ b/app/posts/apply-for-teacher-training/2019-09-18-undergraduate-degree.md
@@ -5,7 +5,6 @@ related:
   items:
   - text: Pull request
     href: https://github.com/DFE-Digital/apply-for-postgraduate-teacher-training-prototype/pull/167
-tags: apply-for-teacher-training
 ---
 A candidate’s undergraudate degree is the most important one. It’s what determines eligibity for postgraduate teacher training.
 

--- a/app/posts/apply-for-teacher-training/2019-10-15-apply-september-2019.md
+++ b/app/posts/apply-for-teacher-training/2019-10-15-apply-september-2019.md
@@ -1,7 +1,6 @@
 ---
 title: Apply – September 2019
 description: A full set of screens showing the design in mid-September.
-tags: apply-for-teacher-training
 ---
 {% from "gallery/macro.njk" import appGallery with context %}
 {{ appGallery({

--- a/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
+++ b/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
@@ -5,7 +5,6 @@ related:
   items:
   - text: Trello ticket
     href: https://trello.com/c/h6HhGrR6
-tags: apply-for-teacher-training
 ---
 An iteration following [an early 2019 design of the journey](/find-teacher-training/choose-how-to-apply-2).
 

--- a/app/posts/apply-for-teacher-training/2019-10-25-amend-withdraw.md
+++ b/app/posts/apply-for-teacher-training/2019-10-25-amend-withdraw.md
@@ -1,7 +1,6 @@
 ---
 title: Amending and withdrawing
 description: Amending applications and withdrawing course choices.
-tags: apply-for-teacher-training
 ---
 First spike to support two features of the application process:
 

--- a/app/posts/apply-for-teacher-training/2019-11-29-apply-launch.md
+++ b/app/posts/apply-for-teacher-training/2019-11-29-apply-launch.md
@@ -1,7 +1,6 @@
 ---
 title: Apply as launched on 26 November 2019
 description: The initial pilot with one provider.
-tags: apply-for-teacher-training
 ---
 On 26 November 2019 we launched the initial Apply pilot with one provider, Royal Academy of Dance (RAD).
 

--- a/app/posts/apply-for-teacher-training/2019-12-05-give-a-reference.md
+++ b/app/posts/apply-for-teacher-training/2019-12-05-give-a-reference.md
@@ -1,7 +1,6 @@
 ---
 title: Give a teacher training reference
 description: Replacing the Google form with an integrated form.
-tags: apply-for-teacher-training
 ---
 One of the first aspects of [the MVP service](/apply-for-teacher-training/apply-launch) we wanted to improve was how we accept references.
 

--- a/app/posts/apply-for-teacher-training/2019-12-06-training-with-a-disability.md
+++ b/app/posts/apply-for-teacher-training/2019-12-06-training-with-a-disability.md
@@ -1,7 +1,6 @@
 ---
 title: Giving details about disability
 description: Training with a disability and reasonable adjustments course choices.
-tags: apply-for-teacher-training
 ---
 Disclosing a disability is a way for candidates to present their disability and needs to a provider, with the potential benefit of making training easier and more accessible.
 

--- a/app/posts/apply-for-teacher-training/apply-for-teacher-training.json
+++ b/app/posts/apply-for-teacher-training/apply-for-teacher-training.json
@@ -2,5 +2,8 @@
   "breadcrumbs": [{
     "text": "Apply for teacher training",
     "href": "/apply-for-teacher-training"
-  }]
+  }],
+  "tags": [
+    "apply-for-teacher-training"
+  ]
 }

--- a/app/posts/find-teacher-training/2019-03-01-performance-march-2019.md
+++ b/app/posts/find-teacher-training/2019-03-01-performance-march-2019.md
@@ -1,7 +1,6 @@
 ---
 title: 'Performance report: March 2019'
 description: We’re 6 months into this year’s recruitment cycle and, for the first time, the Department has data on how candidates are searching for courses.
-tags: find-teacher-training
 ---
 We’re 6 months into this year’s recruitment cycle and, for the first time, the Department has data on how candidates are searching for courses.
 

--- a/app/posts/find-teacher-training/2019-05-01-performance-may-2019.md
+++ b/app/posts/find-teacher-training/2019-05-01-performance-may-2019.md
@@ -1,7 +1,6 @@
 ---
 title: 'Performance report: May 2019'
 description: After 4 months of transitioning providers from UCAS course management to DfE course management, this report focuses on the candidate facing tool and what sorts of behaviours have been coming out of our analytics.
-tags: find-teacher-training
 ---
 The last 4 months have been provider focused. Since the start of 2019, the Find team have been working closely with UCAS to ensure that all training providers with permissions to recruit for postgraduate ITT courses in recruitment cycle 19/20 have access to the new DfE owned course management features.
 

--- a/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
+++ b/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
@@ -5,7 +5,6 @@ related:
   items:
   - text: Trello ticket
     href: https://trello.com/c/FccNwFJ4
-tags: find-teacher-training
 ---
 Towards the end of the recruitment cycle, the current cycle’s courses will mostly be closed to new applications or have only a few vacancies. There will be only a short window to apply.
 

--- a/app/posts/find-teacher-training/2019-09-10-end-of-cycle.md
+++ b/app/posts/find-teacher-training/2019-09-10-end-of-cycle.md
@@ -1,7 +1,6 @@
 ---
 title: Closing search for the end of cycle
 description: Now Apply is closed, disable search until the new cycle begins.
-tags: find-teacher-training
 ---
 A follow-up to our original [end of cycle notice](/find-teacher-training/end-of-cycle-notice). Now that nobody can apply to the 2019/2020 cycle we need to disable search until the new cycle opens on 1 October.
 

--- a/app/posts/find-teacher-training/2019-12-06-find-december-2019.md
+++ b/app/posts/find-teacher-training/2019-12-06-find-december-2019.md
@@ -1,7 +1,6 @@
 ---
 title: Find as of December 2019
 description: A snapshot of the service at the beginning of the 2020 recruitment cycle.
-tags: find-teacher-training
 ---
 A complete snapshot of Find postgraduate teacher training as it looked in December 2019.
 

--- a/app/posts/find-teacher-training/find-teacher-training.json
+++ b/app/posts/find-teacher-training/find-teacher-training.json
@@ -2,5 +2,8 @@
   "breadcrumbs": [{
     "text": "Find postgraduate teacher training",
     "href": "/find-teacher-training"
-  }]
+  }],
+  "tags": [
+    "find-teacher-training"
+  ]
 }

--- a/app/posts/manage-teacher-training-applications/2019-02-19-first-designs.md
+++ b/app/posts/manage-teacher-training-applications/2019-02-19-first-designs.md
@@ -9,7 +9,6 @@ related:
     href: https://bat-manage-teacher-training-applications.herokuapp.com/provider/v01/index
   - text: Original manage applications roadmap
     href: https://docs.google.com/spreadsheets/d/1n4HVUfgKdZXySAFh3KXdCqZ-Ru71DVt7RAxOvl_NO3Y
-tags: manage-teacher-training-applications
 ---
 A minimum viable service that could allow the providers to access and manage their ITT applications.
 

--- a/app/posts/manage-teacher-training-applications/2019-02-21-fewer-statuses.md
+++ b/app/posts/manage-teacher-training-applications/2019-02-21-fewer-statuses.md
@@ -9,7 +9,6 @@ related:
     href: https://bat-manage-teacher-training-applications.herokuapp.com/provider/v02/index
   - text: Minimal and maximal statuses
     href: https://docs.google.com/document/d/1qQOvPcnvskyvwaTqtEUD2CAZjKfcYr7v0rlK_kcDhaA
-tags: manage-teacher-training-applications
 ---
 A minimum viable service that could allow the providers to access and manage their ITT applications.
 

--- a/app/posts/manage-teacher-training-applications/2019-09-04-august-2019.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-04-august-2019.md
@@ -1,7 +1,6 @@
 ---
 title: August 2019 iteration
 description: Create new states with filters.
-tags: manage-teacher-training-applications
 ---
 An update on the [2018 prototype](/manage-teacher-training-applications/better-statuses), bringing the design inline with the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/app/posts/manage-teacher-training-applications/2019-09-18-application-states.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-18-application-states.md
@@ -1,7 +1,6 @@
 ---
 title: Application states
 description: Create new states with filters.
-tags: manage-teacher-training-applications
 ---
 [Pull request](https://github.com/DFE-Digital/manage-teacher-training-applications-prototype/pull/2)
 

--- a/app/posts/manage-teacher-training-applications/2019-09-18-make-an-offer.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-18-make-an-offer.md
@@ -1,7 +1,6 @@
 ---
 title: Make an offer
 description: First pass at making a conditional or unconditional offer.
-tags: manage-teacher-training-applications
 ---
 A simple flow to allow providers to change status and make an offer to a candidate.
 

--- a/app/posts/manage-teacher-training-applications/2019-10-15-minimal-ui.md
+++ b/app/posts/manage-teacher-training-applications/2019-10-15-minimal-ui.md
@@ -1,7 +1,6 @@
 ---
 title: An interface for minimal service provision
 description: Looking towards rolling out the pilot.
-tags: manage-teacher-training-applications
 ---
 Based on research findings from testing earlier versions of the prototype, and having determined the need for a minimal service for managing applications even at the very start of the pilot with SCITTs, we created an updated and stripped-down version of the interface.
 

--- a/app/posts/manage-teacher-training-applications/manage-teacher-training-applications.json
+++ b/app/posts/manage-teacher-training-applications/manage-teacher-training-applications.json
@@ -2,5 +2,8 @@
   "breadcrumbs": [{
     "text": "Manage teacher training applications",
     "href": "/manage-teacher-training-applications"
-  }]
+  }],
+  "tags": [
+    "manage-teacher-training-applications"
+  ]
 }

--- a/app/posts/posts.json
+++ b/app/posts/posts.json
@@ -1,5 +1,7 @@
 {
   "layout": "post",
   "permalink": "{{ page.filePathStem | replace('posts/', '') }}.html",
-  "tags": ["search-index"]
+  "tags": [
+    "search-index"
+  ]
 }

--- a/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard
 description: Create a new course in Publish rather than UCAS.
-tags: publish-teacher-training-courses
 ---
 As part of the [UCAS Transition work](https://docs.google.com/document/d/1H8ecdKnrJ2nJbc87Lgx5t-gx2_jnt0NLYLKf1Y_G9zg/edit#) ([Trello story map](https://trello.com/b/O0RjGYkw/ucas-transition-story-map)) we need to bring course creation into Publish. We [looked at this briefly in May](/publish-teacher-training/new-course-wizard) before we knew we’d have UCAS data.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-15-new-course-2.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-15-new-course-2.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard – 6 December iteration
 description: Consider route into and out of wizard.
-tags: publish-teacher-training-courses
 ---
 This design [tweaks the previous wizard](/publish-teacher-training-courses/new-course) so that:
 

--- a/app/posts/publish-teacher-training-courses/2018-12-16-new-course-locations.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-16-new-course-locations.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard – Training locations
 description: Choosing training locations from the new course wizard.
-tags: publish-teacher-training-courses
 ---
 For providers with multiple training locations we need to ask them which of those locations the course will be running at. Otherwise we can default to their only location.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-17-specific-requirements.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-17-specific-requirements.md
@@ -1,7 +1,6 @@
 ---
 title: Specific course requirements
 description: Documentation on minimum qualifications settings in UCAS web-link and apply.
-tags: publish-teacher-training-courses
 ---
 Providers can set specific requirements for their courses when setting up or editing their training programmes in UCAS web-link.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-18-minimum-course-requirements.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-18-minimum-course-requirements.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard – Minimum course requirements
 description: Choose the minimum course requirements from the new course wizard.
-tags: publish-teacher-training-courses
 ---
 Following on from the [investigation into UCAS specific course requirements](/publish-teacher-training/specific-requirements), a design that comes towards the end of the new course wizard.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-19-edit-title.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-19-edit-title.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard – Confirming course title
 description: Moving the course title fields into the wizard.
-tags: publish-teacher-training-courses
 ---
 An iteration on [the initial design](/publish-teacher-training-courses/new-course-2#customise-title) which:
 

--- a/app/posts/publish-teacher-training-courses/2018-12-20-publish-states.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-20-publish-states.md
@@ -2,7 +2,6 @@
 layout: page
 title: Rethinking the publish workflow
 description: What does the publish workflow look like after UCAS transition?
-tags: publish-teacher-training-courses
 ---
 Publishing before transition was complicated. Each training location had a state and a publish flag, which determines if the course appears in Find and can be applied to on UCAS Apply. Then the content has its own state – Empty, Draft or Published.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-21-vacancies.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-21-vacancies.md
@@ -1,7 +1,6 @@
 ---
 title: Vacancies
 description: First design for changing vacancies at each training location on a course.
-tags: publish-teacher-training-courses
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({

--- a/app/posts/publish-teacher-training-courses/2019-01-10-migrating-publish-statuses.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-10-migrating-publish-statuses.md
@@ -2,7 +2,6 @@
 layout: page
 title: Migrating publish statuses
 description: How old UCAS status and enrichment status should map to a single new status.
-tags: publish-teacher-training-courses
 ---
 How we get from the two statuses we have now (UCAS course running status, and Publish course content status), to a [simpler single course status](/publish-teacher-training-courses/publish-states).
 

--- a/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
@@ -1,7 +1,6 @@
 ---
 title: Course page – 11 January iteration
 description: Edit course information, update the status column.
-tags: publish-teacher-training-courses
 ---
 An iteration on the [current course page](/publish-teacher-training-courses/enrichment-sept-6#course) which:
 

--- a/app/posts/publish-teacher-training-courses/2019-01-14-new-course-iteration-14-jan.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-14-new-course-iteration-14-jan.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard – 14 January iteration
 description: Updates to subjects, minimum requirements and course titles.
-tags: publish-teacher-training-courses
 ---
 In this iteration we changed:
 

--- a/app/posts/publish-teacher-training-courses/2019-01-14-vacancies-iteration-14-jan.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-14-vacancies-iteration-14-jan.md
@@ -1,7 +1,6 @@
 ---
 title: Vacancies – 14 January iteration
 description: Updates to button styles, messaging and validation.
-tags: publish-teacher-training-courses
 ---
 An iteration on [an earlier design](/publish-teacher-training-courses/vacancies).
 

--- a/app/posts/publish-teacher-training-courses/2019-01-28-new-further-education-course.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-28-new-further-education-course.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard – Further education
 description: Designs for the further education path in the new course wizard.
-tags: publish-teacher-training-courses
 ---
 After selecting ‘Further education’ as a course type, the wizard goes down a different path.
 

--- a/app/posts/publish-teacher-training-courses/2019-01-29-edit-course-workflow.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-29-edit-course-workflow.md
@@ -1,7 +1,6 @@
 ---
 title: Edit course information workflow
 description: Workflow diagram for editing course information.
-tags: publish-teacher-training-courses
 ---
 From the course summary page, where answers to questions are listed ([check your answers](/publish-teacher-training-courses/new-course-iteration-14-jan#check-your-answers), [change course information](/publish-teacher-training-courses/new-course-iteration-14-jan#change-course-information)), users expect to edit one answer then return to this page.
 

--- a/app/posts/publish-teacher-training-courses/2019-01-30-preparing-for-locations.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-30-preparing-for-locations.md
@@ -1,7 +1,6 @@
 ---
 title: Preparing for more features
 description: Updating the organisation and courses pages to accommodate new features being added as part of UCAS transition.
-tags: publish-teacher-training-courses
 ---
 A redesign of the organisation page to accommodate new things that providers can do.
 

--- a/app/posts/publish-teacher-training-courses/2019-01-31-new-training-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-31-new-training-location.md
@@ -1,7 +1,6 @@
 ---
 title: Add training location wizard
 description: Add a training location in Publish rather than UCAS.
-tags: publish-teacher-training-courses
 ---
 The first design for adding training locations to an organisation. It follows the same patterns as the [new course wizard](/publish-teacher-training-courses/new-course-iteration-14-jan) – one thing per page, check your answers at the end, back-and-forth editing once the wizard is finished.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-11-new-training-location-region.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-11-new-training-location-region.md
@@ -1,7 +1,6 @@
 ---
 title: Add a region or area workflow
 description: Add a region or area, rather than a school or university.
-tags: publish-teacher-training-courses
 ---
 Following on from the [specific school or university](/publish-teacher-training-courses/new-training-location) workflow, this design builds out the ‘region’ training type.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-12-mvp-add-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-12-mvp-add-location.md
@@ -1,7 +1,6 @@
 ---
 title: Minimum viable Add training location
 description: A replication of what’s available on UCAS. For if we don’t have time to build school autocompletes and other features, with everything else.
-tags: publish-teacher-training-courses
 ---
 A much simplified training location flow. It replicates what is available on UCAS, without any extras.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
@@ -1,7 +1,6 @@
 ---
 title: Accredited body – 5 February iteration
 description: Remove one of the choices, and minimise the chance of error.
-tags: publish-teacher-training-courses
 ---
 The original choice between we are the accredited body versus another organisation is not a valid question. For School Direct they will always need an accredited body. For SCITTs and universities, they are accredited.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
@@ -1,7 +1,6 @@
 ---
 title: Modern Languages – 5 February iteration
 description: Simplify the fields for languages.
-tags: publish-teacher-training-courses
 ---
 Providers model their modern languages courses differently.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-15-status-logic-before-transition.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-15-status-logic-before-transition.md
@@ -1,7 +1,6 @@
 ---
 title: Status logic before UCAS transition
 description: How vacancies, applications and whether a course is on Find is derived from a set of training locations.
-tags: publish-teacher-training-courses
 ---
 ## Training location: Is it on Find?
 

--- a/app/posts/publish-teacher-training-courses/2019-02-16-rollover-reckons.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-16-rollover-reckons.md
@@ -1,7 +1,6 @@
 ---
 title: Rollover reckons
 description: Thoughts on what rollover might look like. And notes on what rollover is right now.
-tags: publish-teacher-training-courses
 ---
 ## UCAS rollover
 

--- a/app/posts/publish-teacher-training-courses/2019-02-17-mvp-add-location-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-17-mvp-add-location-iteration.md
@@ -1,7 +1,6 @@
 ---
 title: Add a location – 13 February iteration
 description: Clarify the purpose of locations.
-tags: publish-teacher-training-courses
 ---
 The term ‘training locations’ is ambiguous.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-21-first-transition-comms.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-21-first-transition-comms.md
@@ -1,7 +1,6 @@
 ---
 title: Email announcing UCAS transition
 description: Sent on Monday 20 February.
-tags: publish-teacher-training-courses
 ---
 {% set emailContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-02-21-rollover-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-21-rollover-wizard.md
@@ -1,7 +1,6 @@
 ---
 title: Rollover wizard
 description: A full rollover wizard, ending in a page with current and next cycles.
-tags: publish-teacher-training-courses
 ---
 Following on from [rollover reckons](/publish-teacher-training-courses/rollover-reckons), this shows a full rollover wizard.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
@@ -1,7 +1,6 @@
 ---
 title: Onboarding workflow and wizard
 description: How does the onboarding process look after UCAS transition?
-tags: publish-teacher-training-courses
 ---
 ## Current process
 

--- a/app/posts/publish-teacher-training-courses/2019-02-27-ucas-apply-preferences.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-27-ucas-apply-preferences.md
@@ -1,7 +1,6 @@
 ---
 title: "UCAS Apply preferences"
 description: Settings such as GT12 letters, Star J, Star X and other requirements.
-tags: publish-teacher-training-courses
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({

--- a/app/posts/publish-teacher-training-courses/2019-03-01-ucas-apply-preferences-2.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-01-ucas-apply-preferences-2.md
@@ -1,7 +1,6 @@
 ---
 title: "UCAS Apply preferences: Letters and alerts"
 description: Only the GT12 letter and email alert preferences are needed.
-tags: publish-teacher-training-courses
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({

--- a/app/posts/publish-teacher-training-courses/2019-03-05-onboarding-wizard-as-google-form.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-05-onboarding-wizard-as-google-form.md
@@ -1,7 +1,6 @@
 ---
 title: Onboarding wizard as a Google form
 description: Capturing contact details, UCAS admin details and first location.
-tags: publish-teacher-training-courses
 ---
 An update on the [original onboarding wizard](/publish-teacher-training-courses/onboarding-wizard). This form is an accompaniment to an initial onboarding call, meaning we don’t have to ask and transcribe answers to these questions.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-05-postcodes.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-05-postcodes.md
@@ -1,7 +1,6 @@
 ---
 title: Postcodes
 description: Asking for, validating and storing postcodes.
-tags: publish-teacher-training-courses
 ---
 We haven’t been validating postcodes in our contact addresses. This raises a few issues:
 

--- a/app/posts/publish-teacher-training-courses/2019-03-05-transition-explainer.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-05-transition-explainer.md
@@ -1,7 +1,6 @@
 ---
 title: Explaining transition
 description: A page transitioned organisations will see when they first log in.
-tags: publish-teacher-training-courses
 ---
 We’re communicating UCAS transition by email. Not everyone will read their email, and some of the new features will not be immediately obvious. The journey on UCAS’s side may not be ideal – we can’t rely on updated messaging or redirects.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-08-deleting-and-withdrawing.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-08-deleting-and-withdrawing.md
@@ -1,7 +1,6 @@
 ---
 title: Deleting and withdrawing
 description: And why there are both.
-tags: publish-teacher-training-courses
 ---
 Deleting a course entirely removes it, it won’t be in the courses table. Providers can only delete courses that haven’t been published in this cycle. Deletions are soft – a developer should be able to restore a course that a provider deletes by mistake.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-08-email-transition-first-batch.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-08-email-transition-first-batch.md
@@ -1,7 +1,6 @@
 ---
 title: Email asking for providers who are available 15-18 April for our first UCAS transition group
 description: Sent on Thursday 7 March.
-tags: publish-teacher-training-courses
 ---
 {% set emailContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-03-08-ucas-contacts.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-08-ucas-contacts.md
@@ -1,7 +1,6 @@
 ---
 title: UCAS settings and contacts
 description: Problems sharing contact information, and how we get around them.
-tags: publish-teacher-training-courses
 ---
 An [update to the UCAS settings design](/publish-teacher-training-courses/ucas-apply-preferences-2) to include UCAS contacts.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-15-requesting-a-title.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-15-requesting-a-title.md
@@ -1,7 +1,6 @@
 ---
 title: Requesting a title
 description: What happens when a provider asks for a custom title.
-tags: publish-teacher-training-courses
 ---
 ## Screenshots
 

--- a/app/posts/publish-teacher-training-courses/2019-03-15-second-transition-email.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-15-second-transition-email.md
@@ -1,7 +1,6 @@
 ---
 title: Email about Publish changes in April
 description: Sent on Wednesday 13 March.
-tags: publish-teacher-training-courses
 ---
 {% set emailContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
@@ -1,7 +1,6 @@
 ---
 title: Tabs on course pages
 description: Splitting course details and enrichments.
-tags: publish-teacher-training-courses
 ---
 An iteration on [the previous design](#old-course-design) where course details and enrichments were shown together.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-25-age-ranges.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-25-age-ranges.md
@@ -1,7 +1,6 @@
 ---
 title: Age ranges
 description: Move age range from an optional question on the subject page to a required question on its own page.
-tags: publish-teacher-training-courses
 ---
 Move age range from an optional question on the subject page to a required question on its own page.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-26-new-location-google-form.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-26-new-location-google-form.md
@@ -1,7 +1,6 @@
 ---
 title: New location as a Google form
 description: An MVP version of the location form we can ship with transition.
-tags: publish-teacher-training-courses
 ---
 Like [new courses](/publish-teacher-training-courses/new-course-google-form), we don’t expect to build the new location features in time for transition.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-02-first-transition-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-02-first-transition-mvp.md
@@ -1,7 +1,6 @@
 ---
 title: An MVP for the first cohort transition from UCAS
 description: A projected cut of the service and how it will look around the time we transition the first and second cohorts from UCAS.
-tags: publish-teacher-training-courses
 ---
 A projected cut of the service and how it will look around the time we transition the first and second cohorts from UCAS.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-05-email-video-comms.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-05-email-video-comms.md
@@ -1,7 +1,6 @@
 ---
 title: Email with video of new vacancies feature
 description: Watch our video about the new Publish teacher training courses.
-tags: publish-teacher-training-courses
 ---
 {% set videoContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-04-09-minimum-requirements-iterations.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-09-minimum-requirements-iterations.md
@@ -1,7 +1,6 @@
 ---
 title: Minimum course requirements – iterations
 description: A view of how the minimum requirements design has been iterated since December.
-tags: publish-teacher-training-courses
 ---
 Progression of the minimum requirements page design:
 

--- a/app/posts/publish-teacher-training-courses/2019-04-09-new-course-wizard-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-09-new-course-wizard-iteration.md
@@ -1,7 +1,6 @@
 ---
 title: New course wizard – iteration
 description: Bring the wizard in line with changes made to the Google Form.
-tags: publish-teacher-training-courses
 ---
 Bring the wizard in line with changes made to the Google Form:
 

--- a/app/posts/publish-teacher-training-courses/2019-04-15-mvp-type-of-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-mvp-type-of-location.md
@@ -1,7 +1,6 @@
 ---
 title: Type of location MVP
 description: A quick way to indicate if a location is an area or an address.
-tags: publish-teacher-training-courses
 ---
 A quick way to indicate if a location is an area or an address.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-15-problems-with-course.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-problems-with-course.md
@@ -1,7 +1,6 @@
 ---
 title: Problems with a course
 description: Exploration into highlighting problems with a course before publishing.
-tags: publish-teacher-training-courses
 ---
 Exploration into highlighting problems with a course before publishing.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-15-tabs-on-locations.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-tabs-on-locations.md
@@ -1,7 +1,6 @@
 ---
 title: Tabs on locations
 description: Show courses at each location and location history.
-tags: publish-teacher-training-courses
 ---
 As part of work looking into how a location might be deleted or removed, it became clear that it was difficult to see which courses a location was assigned to.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
@@ -1,7 +1,6 @@
 ---
 title: Logic mapping UCAS eligibility questions to API codes
 description: Which code should the API sent to UCAS based on a provider’s answers to questions.
-tags: publish-teacher-training-courses
 ---
 UCAS sets a status (1, 2, 3, 9 or n/a) for Maths, English and Science for each course. [This denotes who can apply](/publish-teacher-training-courses/specific-requirements).
 

--- a/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
@@ -1,8 +1,7 @@
 ---
+layout: page
 title: In what order should we build the Edit screens?
 description: List edit screens with their complexity and priority.
-tags: publish-teacher-training-courses
-layout: page
 ---
 [Edit screen workflows in a Google Drawing](https://docs.google.com/drawings/d/1OrJYSTmRSJD2GEAWFnr2lXLNo7A9J9GDsPMQUm0Pi0M/edit) and the [new course flow](https://docs.google.com/drawings/d/1DAhz464j1XDyQPoOH0adIwAceUwuGU1rqsWkVn8ZQ8I/edit) for context.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
@@ -1,8 +1,7 @@
 ---
+layout: page
 title: Publishing during rollover
 description: What does Publish do, what changes?
-tags: publish-teacher-training-courses
-layout: page
 ---
 During rollover there are two cycles: the current cycle, and another that’s being prepared for the next cycle. Courses in the next cycle can’t go live until the cycle begins, which is usually in October.
 

--- a/app/posts/publish-teacher-training-courses/2019-05-14-shipped-for-transition.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-14-shipped-for-transition.md
@@ -1,7 +1,6 @@
 ---
 title: What we shipped for UCAS transition
 description: Locations, location editing and vacancies.
-tags: publish-teacher-training-courses
 ---
 Based on our [transition MVP designs](/publish-teacher-training-courses/first-transition-mvp), when we transitioned all providers away from UCAS we’d shipped the following features:
 

--- a/app/posts/publish-teacher-training-courses/2019-05-20-support-for-missing-features.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-20-support-for-missing-features.md
@@ -1,7 +1,6 @@
 ---
 title: Support for missing features
 description: Filling the gap left by unbuilt features.
-tags: publish-teacher-training-courses
 ---
 Because of the UCAS transition timescales [we’ve shipped without required features](/publish-teacher-training-courses/shipped-for-transition).
 

--- a/app/posts/publish-teacher-training-courses/2019-05-22-courses-as-an-accredited-body.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-22-courses-as-an-accredited-body.md
@@ -1,7 +1,6 @@
 ---
 title: Courses as an accredited body
 description: See which courses you’re the accredited body for.
-tags: publish-teacher-training-courses
 ---
 There is a need for accredited bodies to see the courses they are associated with. UCAS web-link used to give them a read-only view of all courses – running or not, as well as a CSV export of the data.
 

--- a/app/posts/publish-teacher-training-courses/2019-05-31-access-to-multiple-organisations.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-31-access-to-multiple-organisations.md
@@ -1,7 +1,6 @@
 ---
 title: Highlighting the multiple organisations feature
 description: Call out how to get access to more organisations.
-tags: publish-teacher-training-courses
 ---
 Providers can already [manage multiple organisations from a single account](/publish-teacher-training-courses/multiple-organisations). But only providers who have this set up will know about this feature. There are users who don’t know they can do this who are using multiple logins to manage organisations.
 

--- a/app/posts/publish-teacher-training-courses/2019-06-10-minimum-requirements-read-only-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2019-06-10-minimum-requirements-read-only-mvp.md
@@ -1,7 +1,6 @@
 ---
 title: UCAS GCSE requirements – A read only MVP
 description: Show the codes and their meanings to ship earlier.
-tags: publish-teacher-training-courses
 ---
 To implement the [full design](/publish-teacher-training-courses/minimum-course-requirements-logic) we need to fix the data and coerce the model into our representation. The stories are large and sequential.
 

--- a/app/posts/publish-teacher-training-courses/2019-08-06-allocations.md
+++ b/app/posts/publish-teacher-training-courses/2019-08-06-allocations.md
@@ -1,7 +1,6 @@
 ---
 title: Allocations
 description: Show the allocation policy on course detail pages.
-tags: publish-teacher-training-courses
 ---
 {% set html %}
   <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><a href="https://docs.google.com/document/d/1926pN2UTaknKAC4bYUGyCSiPe5lBXJZ33ld7LXmftYw/edit">Original context</a></h4>

--- a/app/posts/publish-teacher-training-courses/2019-09-20-email-new-cycle.md
+++ b/app/posts/publish-teacher-training-courses/2019-09-20-email-new-cycle.md
@@ -1,7 +1,6 @@
 ---
 title: Emails for the new 2019/20 cycle
 description: Prompts and updates for providers.
-tags: publish-teacher-training-courses
 ---
 In the lead up to the opening of the new recruitment cycle on 1 October 2019, we sent these emails.
 

--- a/app/posts/publish-teacher-training-courses/2019-10-15-what-we-did-for-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2019-10-15-what-we-did-for-rollover.md
@@ -1,7 +1,6 @@
 ---
 title: Rollover – what we did in 2019
 description: How we handled our first rollover period.
-tags: publish-teacher-training-courses
 ---
 ## What is rollover?
 

--- a/app/posts/publish-teacher-training-courses/publish-teacher-training-courses.json
+++ b/app/posts/publish-teacher-training-courses/publish-teacher-training-courses.json
@@ -2,5 +2,8 @@
   "breadcrumbs": [{
     "text": "Publish teacher training courses",
     "href": "/publish-teacher-training-courses"
-  }]
+  }],
+  "tags": [
+    "publish-teacher-training-courses"
+  ]
 }

--- a/app/posts/support-for-apply/2019-11-29-prototype-v1.md
+++ b/app/posts/support-for-apply/2019-11-29-prototype-v1.md
@@ -1,7 +1,6 @@
 ---
 title: Support for Apply as designed for MVP
 description: The initial pilot designs
-tags: support-for-apply
 ---
 On 26 November we launched the initial Support for Apply pilot application to let support agents amend applications and import references submitted via Google Forms.
 

--- a/app/posts/support-for-apply/support-for-apply.json
+++ b/app/posts/support-for-apply/support-for-apply.json
@@ -2,5 +2,8 @@
   "breadcrumbs": [{
     "text": "Support for Apply",
     "href": "/support-for-apply"
-  }]
+  }],
+  "tags": [
+    "support-for-apply"
+  ]
 }


### PR DESCRIPTION
* Move collection indices into `collections` folder, so can use default tags in directory data for all posts.
* Delete `tags` field from posts