### PR TITLE
Create a screenshots component with print styles

### DIFF
--- a/app/_components/_all.scss
+++ b/app/_components/_all.scss
@@ -11,4 +11,5 @@
 @import "masthead/masthead";
 @import "prose/prose";
 @import "related/related";
+@import "screenshots/screenshots";
 @import "site-search/site-search";

--- a/app/_components/figure/template.njk
+++ b/app/_components/figure/template.njk
@@ -1,6 +1,11 @@
 {%- from "../embed/macro.njk" import appEmbed with context -%}
 {%- from "../image/macro.njk" import appImage with context -%}
 <figure class="app-figure">
+{% if params.title %}
+  <figcaption class="govuk-heading-m">
+    {{ params.title }}
+  </figcaption>
+{% endif %}
 {% if params.embed %}
   {{ appEmbed({
     placeholder: params.embed.placeholder,

--- a/app/_components/related/template.njk
+++ b/app/_components/related/template.njk
@@ -1,4 +1,4 @@
-<aside class="app-related{%- if params.classes %} {{ params.classes }}{% endif %} app-dont-print" role="complementary">
+<aside class="app-related{%- if params.classes %} {{ params.classes }}{% endif %} app-!-print-display-none" role="complementary">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="{{ params.name }}-title">{{ params.title }}</h2>
   {% if params.content.html or params.content.text %}
   <div class="govuk-body-s">

--- a/app/_components/related/template.njk
+++ b/app/_components/related/template.njk
@@ -1,4 +1,4 @@
-<aside class="app-related{%- if params.classes %} {{ params.classes }}{% endif %}" role="complementary">
+<aside class="app-related{%- if params.classes %} {{ params.classes }}{% endif %} app-dont-print" role="complementary">
   <h2 class="govuk-heading-s govuk-!-margin-bottom-2" id="{{ params.name }}-title">{{ params.title }}</h2>
   {% if params.content.html or params.content.text %}
   <div class="govuk-body-s">

--- a/app/_components/screenshots/_screenshots.scss
+++ b/app/_components/screenshots/_screenshots.scss
@@ -1,0 +1,4 @@
+.app-screenshots__contents,
+.app-screenshots__screenshot {
+  margin-bottom: govuk-spacing(9);
+}

--- a/app/_components/screenshots/_screenshots.scss
+++ b/app/_components/screenshots/_screenshots.scss
@@ -2,3 +2,21 @@
 .app-screenshots__screenshot {
   margin-bottom: govuk-spacing(9);
 }
+
+@include govuk-media-query($media-type: print) {
+  // Separate screenshots from surrounding content
+  .app-screenshots {
+    page-break-before: always;
+    page-break-after: always;
+  }
+
+  .app-screenshots__screenshot {
+    // New page per screenshot
+    page-break-before: always;
+
+    // Hide image URLs
+    a:after {
+      display: none;
+    }
+  }
+}

--- a/app/_components/screenshots/macro.njk
+++ b/app/_components/screenshots/macro.njk
@@ -1,0 +1,3 @@
+{% macro appScreenshots(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -1,7 +1,7 @@
 {%- from "../figure/macro.njk" import appFigure with context -%}
-<section class="govuk-!-margin-top-9" id="screenshots">
-  <h2 class="govuk-heading-l">Screenshots</h2>
-  <ul class="govuk-list app-screenshots__contents">
+<section class="app-screenshots govuk-!-margin-top-9" id="screenshots">
+  <h2 class="govuk-heading-l app-dont-print">Screenshots</h2>
+  <ul class="govuk-list app-screenshots__contents app-dont-print">
     {% for item in params.items %}
       <li>
         <a href="#{{ item.id or (item.text | slug) }}">{{ item.text }}</a>

--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -1,7 +1,7 @@
 {%- from "../figure/macro.njk" import appFigure with context -%}
 <section class="app-screenshots govuk-!-margin-top-9" id="screenshots">
-  <h2 class="govuk-heading-l app-dont-print">Screenshots</h2>
-  <ul class="govuk-list app-screenshots__contents app-dont-print">
+  <h2 class="govuk-heading-l app-!-print-display-none">Screenshots</h2>
+  <ul class="govuk-list app-screenshots__contents app-!-print-display-none">
     {% for item in params.items %}
       <li>
         <a href="#{{ item.id or (item.text | slug) }}">{{ item.text }}</a>

--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -1,0 +1,27 @@
+{%- from "../figure/macro.njk" import appFigure with context -%}
+<section class="govuk-!-margin-top-9" id="screenshots">
+  <h2 class="govuk-heading-l">Screenshots</h2>
+  <ul class="govuk-list app-screenshots__contents">
+    {% for item in params.items %}
+      <li>
+        <a href="#{{ item.id or (item.text | slug) }}">{{ item.text }}</a>
+      </li>
+    {% endfor %}
+  </ul>
+{% for item in params.items -%}
+  {%- set id = item.id or (item.text | slug) -%}
+  {%- set file = item.img.src or (id + ".png") -%}
+  {%- set alt = item.img.alt or ("Screenshot of " + item.text) -%}
+  <div class="app-screenshots__screenshot" id="{{ id }}">
+    {{ appFigure({
+      image: {
+        path: params.path,
+        file: file,
+        alt: alt
+      },
+      title: item.text,
+      caption: item.caption
+    }) }}
+  </div>
+{%- endfor %}
+</section>

--- a/app/_components/site-search/template.njk
+++ b/app/_components/site-search/template.njk
@@ -1,4 +1,4 @@
-<div class="app-site-search" data-module="app-search" data-search-index="/search.json">
+<div class="app-site-search app-dont-print" data-module="app-search" data-search-index="/search.json">
   <label class="govuk-visually-hidden" for="app-site-search__input">{{ params.label }}</label>
   <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
 </div>

--- a/app/_components/site-search/template.njk
+++ b/app/_components/site-search/template.njk
@@ -1,4 +1,4 @@
-<div class="app-site-search app-dont-print" data-module="app-search" data-search-index="/search.json">
+<div class="app-site-search app-!-print-display-none" data-module="app-search" data-search-index="/search.json">
   <label class="govuk-visually-hidden" for="app-site-search__input">{{ params.label }}</label>
   <a class="app-site-search__link govuk-link" href="/sitemap">Sitemap</a>
 </div>

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -25,7 +25,7 @@
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
 {% block footer %}
-  <div class="app-dont-print">
+  <div class="app-!-print-display-none">
     {{ govukFooter({
       navigation: [
         {

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -24,6 +24,41 @@
 
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
+{% block footer %}
+  <div class="app-dont-print">
+    {{ govukFooter({
+      navigation: [
+        {
+          title: "Team links",
+          columns: 1,
+          items: [
+            {
+              text: "Performance dashboard",
+              href: "https://datastudio.google.com/reporting/1M4DgevUBtTVwS09bEpWbkhPxxFqNOBjt"
+            },
+            {
+              text: "Support playbook",
+              href: "https://docs.google.com/document/d/1SV2HWQgRM46dLLEEXHsGADqj1p04Vk6rOcC5VvbDa3A/edit"
+            },
+            {
+              text: "Support model",
+              href: "https://docs.google.com/document/d/1akzv0scmArgVtGcIqYstoQUTXXd823uQBd3SsFK1Ow8/edit"
+            },
+            {
+              text: "Wiki",
+              href: "https://dfedigital.atlassian.net/wiki/spaces/BaT/overview"
+            },
+            {
+              text: "Find team Trello",
+              href: "https://trello.com/b/fXA6ioZN/team-board-find-team"
+            }
+          ]
+        }
+      ]
+    }) }}
+  </div>
+{% endblock %}
+
 {% block bodyEnd %}
   {% block scripts %}
     <script src="/javascripts/govuk-frontend.js"></script>

--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -17,7 +17,7 @@
     image: image if image
   }) %}
     {{ govukBreadcrumbs({
-      classes: "app-breadcrumbs--inverted app-dont-print",
+      classes: "app-breadcrumbs--inverted app-!-print-display-none",
       items: breadcrumbs | breadcrumbs(app, page, title)
     }) if breadcrumbs != false }}
   {% endcall %}

--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -17,7 +17,7 @@
     image: image if image
   }) %}
     {{ govukBreadcrumbs({
-      classes: "app-breadcrumbs--inverted",
+      classes: "app-breadcrumbs--inverted app-dont-print",
       items: breadcrumbs | breadcrumbs(app, page, title)
     }) if breadcrumbs != false }}
   {% endcall %}

--- a/app/_layouts/page.njk
+++ b/app/_layouts/page.njk
@@ -5,7 +5,7 @@
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
-    classes: "app-dont-print",
+    classes: "app-!-print-display-none",
     items: breadcrumbs | breadcrumbs(app, page, title)
   }) if breadcrumbs != false }}
 {% endblock %}

--- a/app/_layouts/page.njk
+++ b/app/_layouts/page.njk
@@ -5,6 +5,7 @@
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
+    classes: "app-dont-print",
     items: breadcrumbs | breadcrumbs(app, page, title)
   }) if breadcrumbs != false }}
 {% endblock %}

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -6,6 +6,7 @@
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
+    classes: "app-dont-print",
     items: breadcrumbs | breadcrumbs(app, page, title)
   }) if breadcrumbs != false }}
 {% endblock %}

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -6,7 +6,7 @@
 
 {% block beforeContent %}
   {{ govukBreadcrumbs({
-    classes: "app-dont-print",
+    classes: "app-!-print-display-none",
     items: breadcrumbs | breadcrumbs(app, page, title)
   }) if breadcrumbs != false }}
 {% endblock %}

--- a/app/_layouts/product.njk
+++ b/app/_layouts/product.njk
@@ -16,7 +16,7 @@
     image: image if image
   }) %}
     {{ govukBreadcrumbs({
-      classes: "app-dont-print",
+      classes: "app-!-print-display-none",
       items: breadcrumbs | breadcrumbs(app, page, title)
     }) if breadcrumbs != false }}
   {% endcall %}

--- a/app/_layouts/product.njk
+++ b/app/_layouts/product.njk
@@ -16,6 +16,7 @@
     image: image if image
   }) %}
     {{ govukBreadcrumbs({
+      classes: "app-dont-print",
       items: breadcrumbs | breadcrumbs(app, page, title)
     }) if breadcrumbs != false }}
   {% endcall %}

--- a/app/_stylesheets/_bat-design-history.scss
+++ b/app/_stylesheets/_bat-design-history.scss
@@ -15,3 +15,14 @@
 .app-tag-published {
   background: govuk-colour("green");
 }
+
+@include govuk-media-query($media-type: print) {
+  .app-dont-print {
+    display: none;
+  }
+
+  // Force a white background when printing a page
+  .govuk-template {
+    background: #fff;
+  }
+}

--- a/app/_stylesheets/_bat-design-history.scss
+++ b/app/_stylesheets/_bat-design-history.scss
@@ -17,8 +17,8 @@
 }
 
 @include govuk-media-query($media-type: print) {
-  .app-dont-print {
-    display: none;
+  .app-\!-print-display-none {
+    display: none !important;
   }
 
   // Force a white background when printing a page

--- a/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
+++ b/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
@@ -22,10 +22,8 @@ The green button takes users to the Find by location page.
 
 This design increased bounce rate on the page from 8% to 18% in the first weeks of September.
 
-## Screenshots
-
-{% from "gallery/macro.njk" import appGallery with context %}
-{{ appGallery({
+{% from "screenshots/macro.njk" import appScreenshots with context %}
+{{ appScreenshots({
   items: [
     {text: "Courses starting in different years"},
     {text: "Iteration showing closing dates"}


### PR DESCRIPTION
- New component added to maintain feature parity with old design history
- Printing a list of screenshots will print 1 per page
- Adds a helper class to avoid printing footer, breadcrumbs, related links and search
- Ports footer from old history

![Screen Shot 2020-01-08 at 11 55 13](https://user-images.githubusercontent.com/319055/71978341-fdf95f00-3212-11ea-96d8-ffb8f56e677a.png)