### PR TITLE
Simplify article template for GOV.UK parity, other small fixes

### DIFF
--- a/app/_components/article/_article.scss
+++ b/app/_components/article/_article.scss
@@ -1,28 +1,4 @@
-.app-article {
-  .app-prose {
-    @include govuk-responsive-margin(6, "top");
-  }
-}
-
-.app-article__header {
-  @include govuk-responsive-padding(2, "bottom");
-}
-
-.app-article__title {
-  @extend %govuk-heading-xl;
-  margin: 0 0 govuk-spacing(2);
-}
-
-.app-article__description {
-  @include govuk-font($size: 24);
-  color: $govuk-secondary-text-colour;
-  margin: 0 0 govuk-spacing(2);
-}
-
 .app-article__footer {
-  @include govuk-responsive-padding(2, "bottom");
-
-  time {
-    color: govuk-colour("dark-grey");
-  }
+  @include govuk-font($size: 19);
+  @include govuk-responsive-margin(9, "top");
 }

--- a/app/_components/article/template.njk
+++ b/app/_components/article/template.njk
@@ -1,24 +1,19 @@
 <article class="app-article">
   {% if params.header %}
   <header class="app-article__header">
-    <h1 class="app-article__title">{{ params.header.title }}</h1>
-    {% if params.header.description %}
-    <p class="app-article__description">{{ params.header.description }}</p>
-    {% endif %}
+    <h1 class="govuk-heading-xl">{{ params.header.title }}</h1>
   </header>
-  {% endif %}
-
-  {% if params.footer %}
-  <footer class="app-article__footer">
-    {% if params.footer.date %}
-    <p class="govuk-body">
-      <time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time>
-    </p>
-    {% endif %}
-  </footer>
   {% endif %}
 
   <div class="app-article__body">
 {{- caller() if caller -}}
   </div>
+
+  {% if params.footer %}
+  <footer class="app-article__footer">
+    {% if params.footer.date %}
+      <time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time>
+    {% endif %}
+  </footer>
+  {% endif %}
 </article>

--- a/app/_components/breadcrumbs/_breadcrumbs.scss
+++ b/app/_components/breadcrumbs/_breadcrumbs.scss
@@ -6,6 +6,7 @@ $app-breadcrumbs-inverted-border-colour: govuk-colour("light-blue");
   margin-top: #{govuk-spacing(4) * -1};
   padding: govuk-spacing(3) 0 govuk-spacing(2);
   border-bottom: 1px solid $app-breadcrumbs-inverted-border-colour;
+  color: $app-breadcrumbs-inverted-text-colour;
 
   @include mq ($from: tablet) {
     margin-top: #{govuk-spacing(6) * -1};
@@ -21,10 +22,7 @@ $app-breadcrumbs-inverted-border-colour: govuk-colour("light-blue");
   }
 
   a:link,
-  a:visited {
-    color: $app-breadcrumbs-inverted-text-colour;
-  }
-
+  a:visited,
   a:hover,
   a:active {
     color: $app-breadcrumbs-inverted-text-colour;

--- a/app/_components/header/template.njk
+++ b/app/_components/header/template.njk
@@ -49,7 +49,7 @@
       </a>
     </div>
     {{ appSiteSearch({
-      label: "Search " + params.productName
+      label: "Search design history"
     }) | indent(4) | trim }}
   </div>
 </header>

--- a/app/_data/app.js
+++ b/app/_data/app.js
@@ -1,4 +1,4 @@
 module.exports = {
-  productName: 'Design History',
+  productName: 'Becoming a teacher design history',
   url: '/'
 }

--- a/lib/filters/breadcrumbs.js
+++ b/lib/filters/breadcrumbs.js
@@ -13,5 +13,12 @@ module.exports = function (breadcrumbs, app, page, title) {
     text: app.serviceName || app.productName,
     href: '/'
   }, breadcrumbs, post).filter(Boolean)
-  return items
+
+  return items.map((item, i, arr) => {
+    if (arr.length - 1 === i) {
+      delete item.href
+    }
+
+    return item
+  });
 }


### PR DESCRIPTION
Keep page templates inline with GOV.UK content, for example: https://www.gov.uk/vehicle-log-book

- Move date to bottom of the page
- Fix alignment of prose with related links
- Remove description – a search description is a summary serving a different purpose to a tagline

A lot of pages also open with content similar to the search description, meaning pages were unnecessarily repeating content. This avoids needing to rewrite them.

Couple of fixes @adamsilver requested:
- Rename product to "Becoming a teacher design history"
- Never link to current page in breadcrumbs
