### PR TITLE
Fix watching

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -22,7 +22,7 @@ module.exports = function (eleventyConfig) {
         'app/_layouts',
         'node_modules/govuk-frontend'
       ], {
-        watch: true
+        watch: process.env.NODE_ENV === 'development'
       }
     ), {
       lstripBlocks: true,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch:files": "eleventy --serve",
     "watch:javascripts": "rollup --config etc/rollup.config.js --watch",
     "watch:styles": "node-sass app/_stylesheets -o public/stylesheets --include-path node_modules/govuk-frontend --watch",
-    "watch": "npm-run-all --parallel watch:*",
+    "watch": "NODE_ENV=development npm-run-all --parallel watch:*",
     "lint": "standard",
     "prestart": "npm run build",
     "start": "nodemon app",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@11ty/eleventy": "^0.9.0",
-    "@11ty/eleventy-plugin-syntaxhighlight": "^2.0.3",
+    "@11ty/eleventy": "^0.10.0",
+    "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.1",
     "accessible-autocomplete": "^2.0.1",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",


### PR DESCRIPTION
- Bump node deps
- Only `watch` Nunjucks components and macros when `NODE_ENV=development` (which is set in `watch` npm script) 