### PR TITLE
Add pagination component and paginate collections

### DIFF
--- a/app/_components/_all.scss
+++ b/app/_components/_all.scss
@@ -9,6 +9,7 @@
 @import "gallery/gallery";
 @import "header/header";
 @import "masthead/masthead";
+@import "pagination/pagination";
 @import "prose/prose";
 @import "related/related";
 @import "screenshots/screenshots";

--- a/app/_components/pagination/_pagination.scss
+++ b/app/_components/pagination/_pagination.scss
@@ -1,0 +1,59 @@
+.app-pagination {
+  @include govuk-font($size: 19);
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid $govuk-border-colour;
+  margin-bottom: govuk-spacing(4);
+  padding-top: govuk-spacing(4);
+
+  a {
+    padding: govuk-spacing(2);
+    text-decoration: none;
+  }
+
+  a:hover {
+    background-color: govuk-colour("light-grey");
+    text-decoration: underline;
+  }
+}
+
+.app-pagination__previous,
+.app-pagination__next {
+  flex-basis: 25%;
+  font-weight: bold;
+  margin: 0 #{govuk-spacing(2) * -1};
+  white-space: nowrap;
+}
+
+.app-pagination__previous {
+  svg {
+    margin-right: govuk-spacing(2);
+  }
+}
+
+.app-pagination__next {
+  text-align: right;
+
+  svg {
+    margin-left: govuk-spacing(2);
+  }
+}
+
+.app-pagination__pages {
+  display: none;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  @include mq ($from: mobile) {
+    display: flex;
+  }
+
+  a {
+    padding: govuk-spacing(2) govuk-spacing(3);
+  }
+
+  a[aria-current] {
+    color: govuk-colour("dark-grey");
+  }
+}

--- a/app/_components/pagination/_pagination.scss
+++ b/app/_components/pagination/_pagination.scss
@@ -1,59 +1,102 @@
 .app-pagination {
-  @include govuk-font($size: 19);
-  display: flex;
-  justify-content: space-between;
-  border-top: 1px solid $govuk-border-colour;
-  margin-bottom: govuk-spacing(4);
-  padding-top: govuk-spacing(4);
+  @include govuk-media-query($from: desktop) {
+    // Alignment adjustments
+    margin-left: - govuk-spacing(1);
+    margin-right: - govuk-spacing(1);
 
-  a {
-    padding: govuk-spacing(2);
-    text-decoration: none;
-  }
+    // Trick to remove the need for floats
+    text-align: justify;
 
-  a:hover {
-    background-color: govuk-colour("light-grey");
-    text-decoration: underline;
+    &:after {
+      content: '';
+      display: inline-block;
+      width: 100%;
+    }
   }
 }
 
-.app-pagination__previous,
-.app-pagination__next {
-  flex-basis: 25%;
-  font-weight: bold;
-  margin: 0 #{govuk-spacing(2) * -1};
-  white-space: nowrap;
-}
-
-.app-pagination__previous {
-  svg {
-    margin-right: govuk-spacing(2);
-  }
-}
-
-.app-pagination__next {
-  text-align: right;
-
-  svg {
-    margin-left: govuk-spacing(2);
-  }
-}
-
-.app-pagination__pages {
-  display: none;
+.app-pagination__list {
   list-style: none;
-  padding: 0;
   margin: 0;
+  padding: 0;
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+}
 
-  @include mq ($from: mobile) {
-    display: flex;
+.app-pagination__results {
+  @include govuk-media-query($from: desktop) {
+    display: inline-block;
+    margin-bottom: 0;
+    vertical-align: middle;
+  }
+}
+
+.app-pagination__item {
+  @include govuk-font(19);
+  display: inline-block;
+}
+
+.app-pagination__item--active,
+.app-pagination__item--dots {
+  font-weight: bold;
+  height: 25px;
+  padding: govuk-spacing(1) govuk-spacing(2);
+  text-align: center;
+}
+
+.app-pagination__item--dots {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.app-pagination__item--prev .app-pagination__link:before,
+.app-pagination__item--next .app-pagination__link:after {
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+  border-style: solid;
+  color: govuk-colour("black");
+  background: transparent;
+  -webkit-transform: rotate(-45deg);
+  -ms-transform: rotate(-45deg);
+  transform: rotate(-45deg);
+  content: "";
+}
+
+.app-pagination__item--prev .app-pagination__link:before {
+  border-width: 3px 0 0 3px;
+  margin-right: govuk-spacing(1);
+}
+
+.app-pagination__item--next .app-pagination__link:after {
+  border-width: 0 3px 3px 0;
+  margin-left: govuk-spacing(1);
+}
+
+.app-pagination__link {
+  display: block;
+  padding: govuk-spacing(1);
+  text-align: center;
+  text-decoration: none;
+  min-width: 25px;
+
+  &:link,
+  &:visited {
+    color: govuk-colour("blue");
   }
 
-  a {
-    padding: govuk-spacing(2) govuk-spacing(3);
-  }
+  &:hover {
+    color: govuk-colour("light-blue");
+   }
 
-  a[aria-current] {
-    color: govuk-colour("dark-grey");
+  &:focus {
+    color: govuk-colour("black");
   }
+}
+
+.app-pagination__results {
+  padding: govuk-spacing(1);
 }

--- a/app/_components/pagination/macro.njk
+++ b/app/_components/pagination/macro.njk
@@ -1,0 +1,3 @@
+{% macro appPagination(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/_components/pagination/template.njk
+++ b/app/_components/pagination/template.njk
@@ -1,27 +1,35 @@
-{%- if params.hrefs | length > 1 -%}
-<nav class="app-pagination" aria-label="pagination">
-  <div class="app-pagination__previous">
-  {%- if params.href.previous -%}
-    <a class="govuk-link--no-visited-state" href="{{ params.href.previous }}" rel="previous">
-      <svg xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13" aria-hidden="true" focusable="false">
-        <path fill="currentColor" d="M6.6 0L-.1 6.7l6.7 6.4L8 11.7l-4.2-4h12.9v-2h-13L8 1.4 6.6 0z"/>
-      </svg>Previous
-    </a>
-  {%- endif -%}
-  </div>
-  <ol class="app-pagination__pages">
-  {%- for href in params.hrefs -%}
-    <li><a class="govuk-link--no-visited-state" href="{{ href }}"{% if params.pageNumber == loop.index0 %} aria-current="page"{% endif %} aria-label="Go to page {{ forloop.index }}">{{ loop.index }}</a></li>
-  {%- endfor -%}
-  </ol>
-  <div class="app-pagination__next">
-  {%- if params.href.next -%}
-    <a class="govuk-link--no-visited-state" href="{{ params.href.next }}" rel="next">
-      Next<svg xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13" aria-hidden="true" focusable="false">
-        <path fill="currentColor" d="M10.1 0L8.7 1.4 13 5.7H0v2h12.9l-4.2 4 1.4 1.4 6.7-6.4L10.1 0z"/>
-      </svg>
-    </a>
-  {%- endif -%}
-  </div>
+{%- if params.items | length > 1 -%}
+<nav class="app-pagination {{- ' ' + params.classes if params.classes}}" id="pagination-label">
+  <p class="govuk-visually-hidden" aria-labelledby="pagination-label">Pagination navigation</p>
+
+  <ul class="app-pagination__list">
+    {%- if params.previous %}
+      <li class="app-pagination__item  app-pagination__item--prev">
+        <a class="app-pagination__link" href="{{ params.previous.href }}">{{ params.previous.text }}<span class="govuk-visually-hidden"> set of pages</span></a>
+      </li>
+    {% endif -%}
+
+    {%- for item in params.items %}
+      {%- if item.type == "dots" %}
+        <li class="app-pagination__item app-pagination__item--dots">…</li>
+      {% else %}
+        {%- if params.selected == loop.index0 %}
+          <li class="app-pagination__item app-pagination__item--active">{{ loop.index }}</li>
+        {% else %}
+          <li class="app-pagination__item"><a class="app-pagination__link" href="{{ item }}">{{ loop.index }}</a></li>
+        {% endif -%}
+      {% endif -%}
+    {% endfor -%}
+
+    {%- if params.next %}
+      <li class="app-pagination__item app-pagination__item--next">
+        <a class="app-pagination__link" href="{{ params.next.href }}">{{ params.next.text }}<span class="govuk-visually-hidden"> set of pages</span></a>
+      </li>
+    {% endif -%}
+  </ul>
+
+  {%- if params.results %}
+    <p class="app-pagination__results">Showing <b>{{ params.results.from }}</b> to <b>{{ params.results.to }}</b> of <b>{{ params.results.count }}</b> results</p>
+  {% endif -%}
 </nav>
 {%- endif -%}

--- a/app/_components/pagination/template.njk
+++ b/app/_components/pagination/template.njk
@@ -1,0 +1,27 @@
+{%- if params.hrefs | length > 1 -%}
+<nav class="app-pagination" aria-label="pagination">
+  <div class="app-pagination__previous">
+  {%- if params.href.previous -%}
+    <a class="govuk-link--no-visited-state" href="{{ params.href.previous }}" rel="previous">
+      <svg xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M6.6 0L-.1 6.7l6.7 6.4L8 11.7l-4.2-4h12.9v-2h-13L8 1.4 6.6 0z"/>
+      </svg>Previous
+    </a>
+  {%- endif -%}
+  </div>
+  <ol class="app-pagination__pages">
+  {%- for href in params.hrefs -%}
+    <li><a class="govuk-link--no-visited-state" href="{{ href }}"{% if params.pageNumber == loop.index0 %} aria-current="page"{% endif %} aria-label="Go to page {{ forloop.index }}">{{ loop.index }}</a></li>
+  {%- endfor -%}
+  </ol>
+  <div class="app-pagination__next">
+  {%- if params.href.next -%}
+    <a class="govuk-link--no-visited-state" href="{{ params.href.next }}" rel="next">
+      Next<svg xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13" aria-hidden="true" focusable="false">
+        <path fill="currentColor" d="M10.1 0L8.7 1.4 13 5.7H0v2h12.9l-4.2 4 1.4 1.4 6.7-6.4L10.1 0z"/>
+      </svg>
+    </a>
+  {%- endif -%}
+  </div>
+</nav>
+{%- endif -%}

--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -1,6 +1,7 @@
 {% extends "product.njk" %}
 
 {% from "document-list/macro.njk" import appDocumentList %}
+{% from "pagination/macro.njk" import appPagination %}
 {% from "prose/macro.njk" import appProse %}
 {% from "related/macro.njk" import appRelated %}
 
@@ -33,8 +34,9 @@
         <section class="govuk-grid-column-two-thirds">
           <h2 class="govuk-heading-l govuk-!-font-size-27">Posts</h2>
           {{ appDocumentList({
-            items: collections[collection] | reverse
+            items: pagination.items
           }) }}
+          {{ appPagination(pagination) }}
         </section>
 
         {% if related %}

--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -36,7 +36,18 @@
           {{ appDocumentList({
             items: pagination.items
           }) }}
-          {{ appPagination(pagination) }}
+          {{ appPagination({
+            previous: {
+              text: "Previous",
+              href: pagination.href.previous
+            } if pagination.href.previous,
+            next: {
+              text: 'Next',
+              href: pagination.href.next
+            } if pagination.href.next,
+            selected: pagination.pageNumber,
+            items: pagination.hrefs
+          }) }}
         </section>
 
         {% if related %}

--- a/app/collections/apply-for-teacher-training.md
+++ b/app/collections/apply-for-teacher-training.md
@@ -11,6 +11,10 @@ related:
       Username: `apply`
       Password: `bat`
     href: https://apply-beta-prototype.herokuapp.com/
-collection: apply-for-teacher-training
+pagination:
+  data: collections.apply-for-teacher-training
+  reverse: true
+  size: 50
+permalink: "apply-for-teacher-training/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% else %}index{% endif %}.html"
 order: 3
 ---

--- a/app/collections/find-teacher-training.md
+++ b/app/collections/find-teacher-training.md
@@ -8,6 +8,10 @@ related:
 breadcrumbs:
   text: Find postgraduate teacher training
   href: /find-teacher-training
-collection: find-teacher-training
+pagination:
+  data: collections.find-teacher-training
+  reverse: true
+  size: 50
+permalink: "find-teacher-training/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% else %}index{% endif %}.html"
 order: 1
 ---

--- a/app/collections/manage-teacher-training-applications.md
+++ b/app/collections/manage-teacher-training-applications.md
@@ -11,6 +11,10 @@ related:
 breadcrumbs:
   text: Manage teacher training applications
   href: /manage-teacher-training-applications
-collection: manage-teacher-training-applications
+pagination:
+  data: collections.manage-teacher-training-applications
+  reverse: true
+  size: 50
+permalink: "manage-teacher-training-applications/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% else %}index{% endif %}.html"
 order: 4
 ---

--- a/app/collections/publish-teacher-training-courses.md
+++ b/app/collections/publish-teacher-training-courses.md
@@ -8,6 +8,10 @@ related:
 breadcrumbs:
   text: Publish teacher training courses
   href: /publish-teacher-training-courses
-collection: publish-teacher-training-courses
+pagination:
+  data: collections.publish-teacher-training-courses
+  reverse: true
+  size: 50
+permalink: "publish-teacher-training-courses/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% else %}index{% endif %}.html"
 order: 2
 ---

--- a/app/collections/support-for-apply.md
+++ b/app/collections/support-for-apply.md
@@ -11,6 +11,10 @@ related:
 breadcrumbs:
   text: Support for Apply
   href: /support-for-apply
-collection: support-for-apply
+pagination:
+  data: collections.support-for-apply
+  reverse: true
+  size: 50
+permalink: "support-for-apply/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% else %}index{% endif %}.html"
 order: 5
 ---


### PR DESCRIPTION
* Adds pagination component
* Adds pagination to collection pages (50 items/page). This means it currently only appears on the ‘Publish’ collection.

Styled using an amalgamation of pagination used on GOV.UK blogs (example: https://aphascience.blog.gov.uk/page/2/) and GOV.UK Whitehall (?) (example: https://www.gov.uk/youth-crime-prevention-programmes/how-young-people-are-put-on-a-programme).

Example:
<img width="670" alt="Screenshot 2020-01-10 at 15 39 36" src="https://user-images.githubusercontent.com/813383/72165508-8b79b200-33bf-11ea-9444-d889aa9d396e.png">

Example when no previous page:
<img width="660" alt="Screenshot 2020-01-10 at 15 38 54" src="https://user-images.githubusercontent.com/813383/72165507-8b79b200-33bf-11ea-913e-47e8e9cc7a62.png">

On my personal site, I rewrite the pagination URLs to use a query, i.e. from `/foo/bar/page2.html` to the more correct `/foo/bar?page=2`, but that can come later.