### PR TITLE
Update article footer appearance, add support for modified dates

### DIFF
--- a/app/_components/article/_article.scss
+++ b/app/_components/article/_article.scss
@@ -1,4 +1,14 @@
+.app-article__body {
+  @include govuk-responsive-margin(8, "bottom");
+
+  *:last-child {
+    margin-bottom: 0;
+  }
+}
+
 .app-article__footer {
-  @include govuk-font($size: 19);
-  @include govuk-responsive-margin(9, "top");
+  @include govuk-font($size: 16, $line-height: 1.5);
+  border-top: 1px solid $govuk-border-colour;
+  padding-top: govuk-spacing(2);
+  max-width: 66%;
 }

--- a/app/_components/article/template.njk
+++ b/app/_components/article/template.njk
@@ -12,7 +12,10 @@
   {% if params.footer %}
   <footer class="app-article__footer">
     {% if params.footer.date %}
-      <time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time>
+      Published <time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time><br>
+    {% endif %}
+    {% if params.footer.modified %}
+      Last updated <time datetime="{{ params.footer.modified | date }}">{{ params.footer.modified | date("d LLLL y") }}</time>
     {% endif %}
   </footer>
   {% endif %}

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -18,7 +18,8 @@
       description: description
     },
     footer: {
-      date: date or page.date
+      date: page.date,
+      modified: modified if modified
     }
   }) %}
   <div class="govuk-grid-row">


### PR DESCRIPTION
* Add support for `modified` front matter field for posts. If used, ‘Last updated’ will appear in post footer.
* Updated design of footer to match that on GOV.UK:

With published date:
<img width="730" alt="Screenshot 2020-01-10 at 17 06 11" src="https://user-images.githubusercontent.com/813383/72171904-caae0000-33cb-11ea-8a14-49e8518e5152.png">

With published and last updated dates:
<img width="690" alt="Screenshot 2020-01-10 at 17 05 50" src="https://user-images.githubusercontent.com/813383/72171903-caae0000-33cb-11ea-8e42-dd51a33a0913.png">