### PR TITLE
Update app search breakpoint for header

### DIFF
--- a/app/_components/site-search/_site-search.scss
+++ b/app/_components/site-search/_site-search.scss
@@ -20,7 +20,7 @@ $icon-size: 40px;
     margin-bottom: govuk-spacing(2);
     float: left;
 
-    @include govuk-media-query($from: desktop) {
+    @include govuk-media-query($from: 900px) {
       float: right;
       margin: 0;
       margin-top: -5px; // Negative margin to vertically align search in header


### PR DESCRIPTION
Surgical fix to tweak when header search box moves to right, (to account for long product name).