### PR TITLE
Update links in footer and move Find specific links to own product page

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -27,34 +27,18 @@
 {% block footer %}
   <div class="app-!-print-display-none">
     {{ govukFooter({
-      navigation: [
-        {
-          title: "Team links",
-          columns: 1,
-          items: [
-            {
-              text: "Performance dashboard",
-              href: "https://datastudio.google.com/reporting/1M4DgevUBtTVwS09bEpWbkhPxxFqNOBjt"
-            },
-            {
-              text: "Support playbook",
-              href: "https://docs.google.com/document/d/1SV2HWQgRM46dLLEEXHsGADqj1p04Vk6rOcC5VvbDa3A/edit"
-            },
-            {
-              text: "Support model",
-              href: "https://docs.google.com/document/d/1akzv0scmArgVtGcIqYstoQUTXXd823uQBd3SsFK1Ow8/edit"
-            },
-            {
-              text: "Wiki",
-              href: "https://dfedigital.atlassian.net/wiki/spaces/BaT/overview"
-            },
-            {
-              text: "Find team Trello",
-              href: "https://trello.com/b/fXA6ioZN/team-board-find-team"
-            }
-          ]
-        }
-      ]
+      meta: {
+        items: [{
+          text: "Support playbook",
+          href: "https://docs.google.com/document/d/1SV2HWQgRM46dLLEEXHsGADqj1p04Vk6rOcC5VvbDa3A/edit"
+        }, {
+          text: "Support model",
+          href: "https://docs.google.com/document/d/1akzv0scmArgVtGcIqYstoQUTXXd823uQBd3SsFK1Ow8/edit"
+        }, {
+          text: "Wiki",
+          href: "https://dfedigital.atlassian.net/wiki/spaces/BaT/overview"
+        }]
+      }
     }) }}
   </div>
 {% endblock %}

--- a/app/collections/find-teacher-training.md
+++ b/app/collections/find-teacher-training.md
@@ -5,6 +5,10 @@ related:
   items:
   - text: Prototype
     href: https://search-and-compare-prototype.herokuapp.com/
+  - text: Team Trello
+    href: https://trello.com/b/fXA6ioZN/team-board-find-team
+  - text: Performance dashboard
+    href: https://datastudio.google.com/reporting/1M4DgevUBtTVwS09bEpWbkhPxxFqNOBjt
 breadcrumbs:
   text: Find postgraduate teacher training
   href: /find-teacher-training


### PR DESCRIPTION
- Reduce overall height of footer by using horizontal `meta` items links.
- Move Find specific links to ’Related’ sidebar on Find service page.