### PR TITLE
Fix off-by-one dates

### DIFF
--- a/app/_components/document-list/template.njk
+++ b/app/_components/document-list/template.njk
@@ -8,10 +8,10 @@
       {% if item.data.description %}
       <p class="app-document-list__item-description">{{ item.data.description | markdown("inline") | safe }}</p>
       {% endif %}
-      {% if (item.data.date or item.date) %}
+      {% if item.date %}
       <ul class="app-document-list__item-metadata">
         <li class="app-document-list__attribute">
-          <time datetime="{{ item.data.date or item.date | date }}">{{ (item.data.date or item.date) | date("d LLLL y") }}</time>
+          <time datetime="{{ item.date | date }}">{{ item.date | date("d LLLL y") }}</time>
         </li>
       </ul>
       {% endif %}

--- a/lib/filters/date.js
+++ b/lib/filters/date.js
@@ -7,12 +7,20 @@ const { DateTime } = require('luxon')
  * @param {String} format Token-based formatting.
  * @example {{ date | date("OPTIONAL FORMAT STRING") }}
  *
- * @see {@link https://moment.github.io/luxon/docs/manual/formatting.html#table-of-tokens List of supported tokens}
  */
-module.exports = (dateObj, format = 'yyyy-LL-dd\'T\'HH:mm:ss.SSSZZ') => {
-  const date = new Date(dateObj)
-  return DateTime.fromJSDate(date, {
+module.exports = (dateObj, format) => {
+  // Convert dateObj to Luxon DateTime object, using UTC
+  // See: https://11ty.dev/docs/dates/#dates-off-by-one-day
+  let date = DateTime.fromJSDate(dateObj, {
     locale: 'en-GB',
     zone: 'utc'
-  }).toFormat(format)
+  })
+
+  // Format date if formatting tokens provided
+  // See: https://moment.github.io/luxon/docs/manual/formatting.html#table-of-tokens
+  if (format) {
+    date = DateTime.fromISO(date).toFormat(format)
+  }
+
+  return date
 }


### PR DESCRIPTION
Think this issue was caused by passing a page’s `date` value through JavaScript’s `Date` method, then handing it off to Luxon’s `DateTime` method.

Also updated `date` filter to not have a default token for formatting dates. Only if format is provided is date passed to `toFormat()` method.