### PR TITLE
Add dates to search results

### DIFF
--- a/app/_components/site-search/_site-search.js
+++ b/app/_components/site-search/_site-search.js
@@ -86,7 +86,7 @@ Search.prototype.resultTemplate = function (result) {
 
     var section = document.createElement('span')
     section.className = 'app-site-search--section'
-    section.innerHTML = result.data.section
+    section.innerHTML = result.data.section + '<br>' + result.dateString
 
     elem.appendChild(section)
     return elem.innerHTML

--- a/app/search.json.njk
+++ b/app/search.json.njk
@@ -10,6 +10,7 @@ permalink: /search.json
       "layout": {{ item.data.layout | dump | safe }}
     },
     "date": {{ item.date | date | dump | safe }},
+    "dateString": {{ item.date  | date("d LLLL y") | dump | safe }},
     "templateContent": {{ item.templateContent | tokenize | dump | safe }},
     "url": {{ item.url | pretty | dump | safe }}
   }{% if not loop.last %},{% endif %}


### PR DESCRIPTION
Include the formatted date in search results to help users decide which entry to click on, and to contextualise the result.

![Screen Shot 2020-01-16 at 12 55 52](https://user-images.githubusercontent.com/319055/72527106-e9931300-385f-11ea-91ac-e2be16f42ca1.png)
