### PR TITLE
Remove tags field from generator scripts

### DIFF
--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -73,9 +73,7 @@ function generatePage () {
   const templateStart = `---
 title: ${title}
 description:
-tags:
 ---
-
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
   items: [`

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -104,9 +104,7 @@ function generatePage () {
   const templateStart = `---
 title: ${title}
 description:
-tags:
 ---
-
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
   items: [`


### PR DESCRIPTION
Removes `tags:` and line break before content from generator scripts. For consistency, innit.