### PR TITLE
Force HTTPs

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,24 @@ const port = process.env.PORT || 8000
 const staticDir = path.join(__dirname, 'public')
 
 const app = express()
+const env = (process.env.NODE_ENV || 'development').toLowerCase()
+
+// Force HTTPS on production
+// Based on the govuk-prototype-kit
+if (env === 'production') {
+  app.use(function (req, res, next) {
+    if (req.headers['x-forwarded-proto'] !== 'https') {
+      // 302 temporary - this is a feature that can be disabled
+      return res.redirect(302, 'https://' + req.get('Host') + req.url)
+    }
+
+    // Mark proxy as secure (allows secure cookies)
+    req.connection.proxySecure = true
+    next()
+  })
+
+  app.set('trust proxy', 1) // needed for secure cookies on heroku
+}
 
 app.use(express.static(staticDir, {
   extensions: 'html',


### PR DESCRIPTION
Use the same logic as the govuk-prototype kit for forcing HTTPs on Heroku