### PR TITLE
Add date field to posts, ensure future generated posts have dates too

### DIFF
--- a/app/posts/apply-for-teacher-training/2018-04-30-apply-april-2018.md
+++ b/app/posts/apply-for-teacher-training/2018-04-30-apply-april-2018.md
@@ -1,7 +1,7 @@
 ---
 title: Apply – April 2018
 description: Application and summary.
-date: 2019-02-17
+date: 2018-04-30
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2018-05-31-apply-may-2018.md
+++ b/app/posts/apply-for-teacher-training/2018-05-31-apply-may-2018.md
@@ -1,7 +1,7 @@
 ---
 title: Apply – May 2018
 description: About you, qualifications and experience.
-date: 2019-02-17
+date: 2018-05-31
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2018-08-31-apply-august-2018.md
+++ b/app/posts/apply-for-teacher-training/2018-08-31-apply-august-2018.md
@@ -1,7 +1,7 @@
 ---
 title: Apply – August 2018
 description: The Apply designs as they stood at the end of August 2018.
-date: 2019-02-19
+date: 2018-08-31
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2018-12-31-apply-december-2018.md
+++ b/app/posts/apply-for-teacher-training/2018-12-31-apply-december-2018.md
@@ -1,7 +1,7 @@
 ---
 title: Apply – December 2018
 description: The Apply designs as they stood at the end of December 2018.
-date: 2019-02-19
+date: 2018-12-31
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2019-02-17-apply-april-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-17-apply-april-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Apply – April 2018
 description: Application and summary.
+date: 2019-02-17
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2019-02-17-apply-may-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-17-apply-may-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Apply – May 2018
 description: About you, qualifications and experience.
+date: 2019-02-17
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2019-02-19-apply-august-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-19-apply-august-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Apply – August 2018
 description: The Apply designs as they stood at the end of August 2018.
+date: 2019-02-19
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2019-02-19-apply-december-2018.md
+++ b/app/posts/apply-for-teacher-training/2019-02-19-apply-december-2018.md
@@ -1,6 +1,7 @@
 ---
 title: Apply – December 2018
 description: The Apply designs as they stood at the end of December 2018.
+date: 2019-02-19
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2019-02-20-free-form-application.md
+++ b/app/posts/apply-for-teacher-training/2019-02-20-free-form-application.md
@@ -1,6 +1,7 @@
 ---
 title: Free form application and qualifications
 description: More free text, less structured data.
+date: 2019-02-20
 related:
   items:
   - text: Prototype

--- a/app/posts/apply-for-teacher-training/2019-02-20-progressive-application.md
+++ b/app/posts/apply-for-teacher-training/2019-02-20-progressive-application.md
@@ -1,6 +1,7 @@
 ---
 title: Progressive application
 description: Ask for further information only when needed.
+date: 2019-02-20
 ---
 Our designer Vin documented these on [Confluence](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/279314433/Designs) (Project Bluesky).
 

--- a/app/posts/apply-for-teacher-training/2019-05-02-paper-based-application.md
+++ b/app/posts/apply-for-teacher-training/2019-05-02-paper-based-application.md
@@ -1,6 +1,7 @@
 ---
 title: Prototyping with paper-based application forms
 description: Testing hypotheses and preparing for a concierged service.
+date: 2019-05-02
 ---
 Before building a fully DfE operated apply service, we wanted to test certain elements of an end-to-end minimum viable product. We began with a series of hypotheses, two of which related to the design of the application form and the information given to providers. These hypotheses were:
 

--- a/app/posts/apply-for-teacher-training/2019-08-01-beta-version-1.md
+++ b/app/posts/apply-for-teacher-training/2019-08-01-beta-version-1.md
@@ -1,6 +1,7 @@
 ---
 title: Creating our first interactive prototype
 description: Testing an interactive version of the application form.
+date: 2019-08-01
 related:
   items:
   - text: Prototype v1

--- a/app/posts/apply-for-teacher-training/2019-08-16-magic-link-login.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-magic-link-login.md
@@ -1,6 +1,7 @@
 ---
 title: Sign up and log in using a magic link
 description: An alternative to using an account and password.
+date: 2019-08-16
 ---
 An alternative to the [account and password design](/apply-for-teacher-training/apply-june-2019/create-account).
 

--- a/app/posts/apply-for-teacher-training/2019-08-16-pick-a-course.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-pick-a-course.md
@@ -1,6 +1,7 @@
 ---
 title: Picking courses to apply to
 description: Providing a route to Find, or selecting the course you want.
+date: 2019-08-16
 ---
 Candidates using Apply need to choose a course to apply to.
 

--- a/app/posts/apply-for-teacher-training/2019-08-16-submitted-application.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-submitted-application.md
@@ -1,6 +1,7 @@
 ---
 title: Submitted application
 description: Applications page and read only view.
+date: 2019-08-16
 ---
 Once a user has submitted at least one application, when they return to Apply the first thing they should see is their application status.
 

--- a/app/posts/apply-for-teacher-training/2019-08-16-work-history.md
+++ b/app/posts/apply-for-teacher-training/2019-08-16-work-history.md
@@ -1,6 +1,7 @@
 ---
 title: Work history - August iteration
 description: Move guidance into a question.
+date: 2019-08-16
 ---
 Following on from [the original design](/apply-for-teacher-training/apply-june-2019/work-history), rather than using multiple details elements and two submit button we’ve shaped the guidance as a question and used routing based on their answer to send users to the right place.
 

--- a/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
+++ b/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
@@ -1,6 +1,7 @@
 ---
 title: Removing the teaching profile
 description: Why we removed it, and the alternative.
+date: 2019-08-19
 ---
 [In the July 2019 prototype](https://apply-beta-prototype-v1.herokuapp.com/) ([screenshots](/apply-for-teacher-training/apply-june-2019/personal-details)) we tested a version of the application where course choice was separated from your teaching profile. Your teaching profile was a shareable or reusable profile that would be pulled into each application.
 

--- a/app/posts/apply-for-teacher-training/2019-09-04-cover-letters.md
+++ b/app/posts/apply-for-teacher-training/2019-09-04-cover-letters.md
@@ -1,6 +1,7 @@
 ---
 title: Cover letters
 description: Creating a place to customise what’s sent to each provider.
+date: 2019-09-04
 related:
   items:
   - text: Trello ticket

--- a/app/posts/apply-for-teacher-training/2019-09-18-equality-monitoring.md
+++ b/app/posts/apply-for-teacher-training/2019-09-18-equality-monitoring.md
@@ -1,6 +1,7 @@
 ---
 title: Equality monitoring
-description: First pass at asking for information for monitoring equality
+description: First pass at asking for information for monitoring equality.
+date: 2019-08-18
 related:
   items:
   - text: HESA Initial Teacher Training record 2019/20

--- a/app/posts/apply-for-teacher-training/2019-09-18-undergraduate-degree.md
+++ b/app/posts/apply-for-teacher-training/2019-09-18-undergraduate-degree.md
@@ -1,6 +1,7 @@
 ---
 title: Asking for an undergraduate degree
 description: Get the most important degree details first.
+date: 2019-09-18
 related:
   items:
   - text: Pull request

--- a/app/posts/apply-for-teacher-training/2019-10-15-apply-september-2019.md
+++ b/app/posts/apply-for-teacher-training/2019-10-15-apply-september-2019.md
@@ -1,6 +1,7 @@
 ---
 title: Apply – September 2019
 description: A full set of screens showing the design in mid-September.
+date: 2019-10-15
 ---
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({

--- a/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
+++ b/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
@@ -1,6 +1,7 @@
 ---
 title: From Find to Apply
 description: User journey and screenshots for a new user.
+date: 2019-10-23
 related:
   items:
   - text: Trello ticket

--- a/app/posts/apply-for-teacher-training/2019-10-25-amend-withdraw.md
+++ b/app/posts/apply-for-teacher-training/2019-10-25-amend-withdraw.md
@@ -1,6 +1,7 @@
 ---
 title: Amending and withdrawing
 description: Amending applications and withdrawing course choices.
+date: 2019-10-25
 ---
 First spike to support two features of the application process:
 

--- a/app/posts/apply-for-teacher-training/2019-11-29-apply-launch.md
+++ b/app/posts/apply-for-teacher-training/2019-11-29-apply-launch.md
@@ -1,6 +1,7 @@
 ---
 title: Apply as launched on 26 November 2019
 description: The initial pilot with one provider.
+date: 2019-11-29
 ---
 On 26 November 2019 we launched the initial Apply pilot with one provider, Royal Academy of Dance (RAD).
 

--- a/app/posts/apply-for-teacher-training/2019-12-05-give-a-reference.md
+++ b/app/posts/apply-for-teacher-training/2019-12-05-give-a-reference.md
@@ -1,6 +1,7 @@
 ---
 title: Give a teacher training reference
 description: Replacing the Google form with an integrated form.
+date: 2019-12-05
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({ html: 'We built a <a href="/apply-for-teacher-training/give-a-reference-iteration">simpler version of this design</a>.', iconFallbackText: "Warning" }) }}

--- a/app/posts/apply-for-teacher-training/2019-12-06-training-with-a-disability.md
+++ b/app/posts/apply-for-teacher-training/2019-12-06-training-with-a-disability.md
@@ -1,6 +1,7 @@
 ---
 title: Giving details about disability
 description: Training with a disability and reasonable adjustments course choices.
+date: 2019-12-06
 ---
 Disclosing a disability is a way for candidates to present their disability and needs to a provider, with the potential benefit of making training easier and more accessible.
 

--- a/app/posts/apply-for-teacher-training/2020-01-16-question-protocol-for-pilot.md
+++ b/app/posts/apply-for-teacher-training/2020-01-16-question-protocol-for-pilot.md
@@ -1,7 +1,8 @@
 ---
 layout: page
 title: What we ask for and why
-description: A question protocol
+description: A question protocol.
+date: 2020-01-16
 ---
 Below is a snapshot of the questions we ask (or intended to ask) candidates for the initial launch of the pilot. From [the service manual page about structuring forms](https://www.gov.uk/service-manual/design/form-structure):
 

--- a/app/posts/apply-for-teacher-training/2020-01-20-give-a-reference-iteration.md
+++ b/app/posts/apply-for-teacher-training/2020-01-20-give-a-reference-iteration.md
@@ -1,9 +1,9 @@
 ---
 title: Give a teacher training reference (iteration)
-description: Simplifying the previous design
+description: Simplifying the previous design.
+date: 2020-01-20
 tags: awaiting-validation
 ---
-
 An [iteration on the initial design](/apply-for-teacher-training/give-a-reference), removing some of the unnecessary fields.
 
 ## User needs

--- a/app/posts/apply-for-teacher-training/2020-01-20-part-time-working-hours.md
+++ b/app/posts/apply-for-teacher-training/2020-01-20-part-time-working-hours.md
@@ -1,6 +1,7 @@
 ---
 title: Working patterns for part time jobs
-description: Adding a place for candidates to describe their working pattern
+description: Adding a place for candidates to describe their working pattern.
+date: 2020-01-20
 ---
 We ask candidates to select ‘full time’ or ‘part time’ for their work history entries.
 

--- a/app/posts/apply-for-teacher-training/2020-01-21-suitability-to-work-with-children.md
+++ b/app/posts/apply-for-teacher-training/2020-01-21-suitability-to-work-with-children.md
@@ -1,6 +1,7 @@
 ---
 title: Suitability to work with children
 description: Add a section to disclose convictions or anything that could affect suitability to work with children.
+date: 2020-01-21
 related:
   items:
   - text: Trello ticket

--- a/app/posts/apply-for-teacher-training/2020-01-21-work-history-and-volunteering.md
+++ b/app/posts/apply-for-teacher-training/2020-01-21-work-history-and-volunteering.md
@@ -1,6 +1,7 @@
 ---
 title: Work history and volunteering guidance
 description: Making sure providers get the information they need about a candidate's (unpaid) work history.
+date: 2020-01-21
 ---
 We want candidates to tell us about their paid work experience on one page and their unpaid experience or volunteering on another page.
 
@@ -31,7 +32,7 @@ Teacher training providers are not allowed to make school experience a prerequis
 
 Presenting the application form in a way that values school experience over other types of experience isn't fair on the candidate. It makes it more likely that the candidate omits other types of experience.
 
-A couple of providers echoed these concerns. For example, Bedfordshire University said that the guidance could discourage candidates from including some types of work. This is the opposite of what they want to achieve: a big picture of the candidate.   
+A couple of providers echoed these concerns. For example, Bedfordshire University said that the guidance could discourage candidates from including some types of work. This is the opposite of what they want to achieve: a big picture of the candidate.
 
 ### Our hypothesis
 

--- a/app/posts/apply-for-teacher-training/apply-june-2019/2019-08-16-index.md
+++ b/app/posts/apply-for-teacher-training/apply-june-2019/2019-08-16-index.md
@@ -3,6 +3,7 @@ eleventyExcludeFromCollections: false
 layout: post
 title: Apply – June 2019
 description: A full set of screens showing the design in June 2019, broken down by section.
+date: 2019-08-16
 related:
   items:
   - text: Write-up of prototype and research

--- a/app/posts/find-teacher-training/2018-05-01-ucas-course-examples.md
+++ b/app/posts/find-teacher-training/2018-05-01-ucas-course-examples.md
@@ -1,6 +1,7 @@
 ---
 title: UCAS course examples
-description: Examples of courses on UCAS search
+description: Examples of courses on UCAS search.
+date: 2018-05-01
 ---
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({

--- a/app/posts/find-teacher-training/2018-05-01-ucas-search.md
+++ b/app/posts/find-teacher-training/2018-05-01-ucas-search.md
@@ -1,6 +1,7 @@
 ---
 title: UCAS teacher training (search)
-description: Screenshots of the UCAS service that Find replaced
+description: Screenshots of the UCAS service that Find replaced.
+date: 2018-05-01
 tags: ucas
 ---
 Screenshots of the UCAS search tool that Find postgraduate teacher training replaced in 2018.

--- a/app/posts/find-teacher-training/2018-06-11-course-options-user-research-june-8.md
+++ b/app/posts/find-teacher-training/2018-06-11-course-options-user-research-june-8.md
@@ -1,6 +1,7 @@
 ---
 title: Folded courses research 8 June 2018
 description: Testing study options in search results and on the course information page.
+date: 2018-06-11
 ---
 We tested a hypothesis around folding courses - eg salaried and unsalaried folded into one course listing and course detail page. (More on folding: ‘[What is a course?](/publish-teacher-training-courses/what-is-a-course)’, [folding detail](/publish-teacher-training-courses/imported-from-ucas))
 

--- a/app/posts/find-teacher-training/2018-07-20-all-courses-minimum.md
+++ b/app/posts/find-teacher-training/2018-07-20-all-courses-minimum.md
@@ -1,6 +1,7 @@
 ---
 title: Just the UCAS data
 description: What an absolute minimum viable service might look like.
+date: 2018-07-20
 ---
 To deliver a viable service by October we are aggressively reducing scope, limiting many features to their irreducible core. When we have built the minimum viable service, we can begin to improve on features to better meet user needs. This is being tracked using a [Story map in Trello](https://trello.com/b/9fCxMchD/bat-search-story-map).
 

--- a/app/posts/find-teacher-training/2018-07-25-mvp-iteration-jul-25.md
+++ b/app/posts/find-teacher-training/2018-07-25-mvp-iteration-jul-25.md
@@ -1,6 +1,7 @@
 ---
 title: Just the UCAS data – 25 July iteration
 description: Tweaks to the minimum viable service including improved subject selection.
+date: 2018-07-25
 ---
 Improvements to the [minimum viable service](/find-teacher-training/all-courses-minimum) include:
 

--- a/app/posts/find-teacher-training/2018-09-25-subjects-bursaries-and-skes.md
+++ b/app/posts/find-teacher-training/2018-09-25-subjects-bursaries-and-skes.md
@@ -1,6 +1,7 @@
 ---
 title: Subjects, bursaries and SKE courses
 description: An iteration on the MVP, with full course pages and a subject filter with bursary and SKE information.
+date: 2018-09-25
 ---
 We tested this design with 4 users:
 

--- a/app/posts/find-teacher-training/2018-10-02-fe-and-pgde.md
+++ b/app/posts/find-teacher-training/2018-10-02-fe-and-pgde.md
@@ -1,6 +1,7 @@
 ---
 title: PGDE and further education courses
-description: We quickly iterated fixes to correctly indicate qualifications on these courses
+description: We quickly iterated fixes to correctly indicate qualifications on these courses.
+date: 2018-10-02
 ---
 We started with two qualification options:
 

--- a/app/posts/find-teacher-training/2018-10-02-live-launch.md
+++ b/app/posts/find-teacher-training/2018-10-02-live-launch.md
@@ -1,6 +1,7 @@
 ---
 title: What we launched – 2 October 2018
 description: Our live public beta launch.
+date: 2018-10-02
 ---
 On 2 October 2018 we launched the public beta of Find posgraduate teacher training to users. This included a new start page on GOV.UK and links to it from UCAS and Get into Teaching.
 

--- a/app/posts/find-teacher-training/2018-10-06-map-original.md
+++ b/app/posts/find-teacher-training/2018-10-06-map-original.md
@@ -1,6 +1,7 @@
 ---
 title: Results on a map – Early design with tweaks
 description: Map based on code written during alpha/private-beta with some recent tweaks.
+date: 2018-10-06
 tags: maps
 ---
 {% from "screenshots/macro.njk" import appScreenshots with context %}

--- a/app/posts/find-teacher-training/2018-10-07-experimental-map.md
+++ b/app/posts/find-teacher-training/2018-10-07-experimental-map.md
@@ -1,6 +1,7 @@
 ---
 title: Results on a map – Full screen
 description: First pass at showing courses on a full screen map.
+date: 2018-10-07
 tags: maps
 ---
 A first pass at putting search results on a full-width map.

--- a/app/posts/find-teacher-training/2018-10-18-experimental-map-iteration.md
+++ b/app/posts/find-teacher-training/2018-10-18-experimental-map-iteration.md
@@ -1,6 +1,7 @@
 ---
 title: Results on a map – Full screen iteration
 description: Second pass at showing courses on a full screen map.
+date: 2018-10-18
 tags: maps
 ---
 An iteration on the [first pass](/find-teacher-training/experimental-map/) of putting search results on a full-width map. This design adds:

--- a/app/posts/find-teacher-training/2018-10-19-map-2.md
+++ b/app/posts/find-teacher-training/2018-10-19-map-2.md
@@ -1,6 +1,7 @@
 ---
 title: Results on a map – User research 18 October
 description: A combination of the full screen and original design.
+date: 2018-10-19
 tags: maps
 ---
 We tested a new iteration of maps with 5 users on 18 October 2018. It is a combination of the best bits of the previous two designs which we tested together.

--- a/app/posts/find-teacher-training/2018-10-31-map-3.md
+++ b/app/posts/find-teacher-training/2018-10-31-map-3.md
@@ -1,6 +1,7 @@
 ---
 title: Results on a map – Text on labels
-description: A further map iteration
+description: A further map iteration.
+date: 2018-10-31
 tags: maps
 ---
 A further iteration on the maps design following user research on [18 October](/find-teacher-training/map-2).

--- a/app/posts/find-teacher-training/2018-11-02-map-4.md
+++ b/app/posts/find-teacher-training/2018-11-02-map-4.md
@@ -1,6 +1,7 @@
 ---
 title: Showing a map in the filters column
 description: Clarify where a user is searching on the list view.
+date: 2018-11-02
 ---
 When we had a ‘View on map’ link it wasn’t seen by users, we had to prompt them to open it to see the map.
 

--- a/app/posts/find-teacher-training/2018-11-02-sen-filter.md
+++ b/app/posts/find-teacher-training/2018-11-02-sen-filter.md
@@ -1,6 +1,7 @@
 ---
 title: Special educational needs (SEN) filter
 description: SEN is a subject, but also not a subject. Any subject could have an SEN focus.
+date: 2018-11-02
 tags: send
 ---
 Users have struggled to find SEN courses because SEN is not listed as a subject anywhere.

--- a/app/posts/find-teacher-training/2018-11-19-static-service.md
+++ b/app/posts/find-teacher-training/2018-11-19-static-service.md
@@ -1,6 +1,7 @@
 ---
 title: Static failover service
 description: If we had to provide a site without any dynamic features, how would it look.
+date: 2018-11-19
 ---
 When there is a catastrophic failure with Find and the team’s not around to pair on fixing the issue (eg near Christmas when lots of people have leave), it’s desirable to have a way to meet user needs without dynamic code. For example some linked static pages that allow candidates to browse courses. Having a static failover would allow a simple disaster recovery process eg. flip the DNS to point to the static site.
 

--- a/app/posts/find-teacher-training/2018-11-21-tweaked-course-titles.md
+++ b/app/posts/find-teacher-training/2018-11-21-tweaked-course-titles.md
@@ -1,6 +1,7 @@
 ---
 title: Iterate course titles
 description: Make it easier to differentiate between search results.
+date: 2018-11-21
 ---
 Search results must be distinct, and the differences between courses must be clear. When a provider offers multiple courses for the same subject, it’s not obvious to users what the difference is ([see BHSSA example](/images/find-teacher-training/live-launch/search-results.png)).
 

--- a/app/posts/find-teacher-training/2018-11-27-maps-for-providers-with-many-partners.md
+++ b/app/posts/find-teacher-training/2018-11-27-maps-for-providers-with-many-partners.md
@@ -1,6 +1,7 @@
 ---
 title: Maps for providers with many partner schools
 description: What does good look like for providers with many partner schools?
+date: 2018-11-27
 ---
 From research with providers we found that for courses offered by large SCITTs and universities we didn’t have enough data to accurately tell candidates the full story around location. This also applies to growing school direct alliances (for example [Trinity TSA](https://find-postgraduate-teacher-training.education.gov.uk/course/1YF/2QL9)).
 

--- a/app/posts/find-teacher-training/2019-02-15-choose-how-to-apply.md
+++ b/app/posts/find-teacher-training/2019-02-15-choose-how-to-apply.md
@@ -1,6 +1,7 @@
 ---
 title: Choose how to apply
-description: User journey into UCAS or new Apply service
+description: User journey into UCAS or new Apply service.
+date: 2019-02-15
 ---
 Initial designs to test the impact of giving candidates a choice on how they should apply.
 

--- a/app/posts/find-teacher-training/2019-02-15-send-survey.md
+++ b/app/posts/find-teacher-training/2019-02-15-send-survey.md
@@ -1,6 +1,7 @@
 ---
 title: SEND survey and updates
 description: Research and findings into courses with a SEND specialism
+date: 2019-02-15
 tags: send
 ---
 A record of [this Google Doc](https://docs.google.com/document/d/1Cxu1X3SKwRWlVTIp5PAiiKsBUMi7YoeDIJxu-77uPzs/edit).

--- a/app/posts/find-teacher-training/2019-02-27-choose-how-to-apply-2.md
+++ b/app/posts/find-teacher-training/2019-02-27-choose-how-to-apply-2.md
@@ -1,6 +1,7 @@
 ---
 title: Choose how to apply – Iteration and research
 description: An updated journey into UCAS or new Apply service, tested with users.
+date: 2019-02-27
 ---
 Following on from the [initial design](/find-teacher-training/choose-how-to-apply).
 

--- a/app/posts/find-teacher-training/2019-03-01-performance-march-2019.md
+++ b/app/posts/find-teacher-training/2019-03-01-performance-march-2019.md
@@ -1,6 +1,7 @@
 ---
 title: Performance report - March 2019
 description: We’re 6 months into this year’s recruitment cycle and, for the first time, the Department has data on how candidates are searching for courses.
+date: 2019-03-01
 ---
 We’re 6 months into this year’s recruitment cycle and, for the first time, the Department has data on how candidates are searching for courses.
 

--- a/app/posts/find-teacher-training/2019-03-26-financial-incentives-multiple-subjects.md
+++ b/app/posts/find-teacher-training/2019-03-26-financial-incentives-multiple-subjects.md
@@ -1,7 +1,7 @@
 ---
 title: Financial incentives
 description: Changes made to the financial incentives logic for courses with multiple subjects.
-tags:
+date: 2019-03-26
 ---
 ## What is the problem?
 

--- a/app/posts/find-teacher-training/2019-05-01-performance-may-2019.md
+++ b/app/posts/find-teacher-training/2019-05-01-performance-may-2019.md
@@ -1,6 +1,7 @@
 ---
 title: Performance report - May 2019
 description: After 4 months of transitioning providers from UCAS course management to DfE course management, this report focuses on the candidate facing tool and what sorts of behaviours have been coming out of our analytics.
+date: 2019-05-01
 ---
 The last 4 months have been provider focused. Since the start of 2019, the Find team have been working closely with UCAS to ensure that all training providers with permissions to recruit for postgraduate ITT courses in recruitment cycle 19/20 have access to the new DfE owned course management features.
 

--- a/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
+++ b/app/posts/find-teacher-training/2019-08-30-end-of-cycle-notice.md
@@ -1,6 +1,7 @@
 ---
 title: An end of cycle notice
 description: Tell users which year’s courses they are searching.
+date: 2019-08-30
 related:
   items:
   - text: Trello ticket

--- a/app/posts/find-teacher-training/2019-09-10-end-of-cycle.md
+++ b/app/posts/find-teacher-training/2019-09-10-end-of-cycle.md
@@ -1,6 +1,7 @@
 ---
 title: Closing search for the end of cycle
 description: Now Apply is closed, disable search until the new cycle begins.
+date: 2019-09-10
 ---
 A follow-up to our original [end of cycle notice](/find-teacher-training/end-of-cycle-notice). Now that nobody can apply to the 2019/2020 cycle we need to disable search until the new cycle opens on 1 October.
 

--- a/app/posts/find-teacher-training/2019-12-06-find-december-2019.md
+++ b/app/posts/find-teacher-training/2019-12-06-find-december-2019.md
@@ -1,6 +1,7 @@
 ---
 title: Find as of December 2019
 description: A snapshot of the service at the beginning of the 2020 recruitment cycle.
+date: 2019-12-06
 ---
 A complete snapshot of Find postgraduate teacher training as it looked in December 2019.
 

--- a/app/posts/find-teacher-training/alpha/2017-10-01-alpha-version-1.md
+++ b/app/posts/find-teacher-training/alpha/2017-10-01-alpha-version-1.md
@@ -1,9 +1,7 @@
 ---
 title: Alpha version 1
-description:
-tags:
+date: 2017-10-01
 ---
-
 [Version 1 prototype](https://search-and-compare-alpha.herokuapp.com/search/v01/index2)
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}

--- a/app/posts/find-teacher-training/alpha/2017-10-10-alpha-version-2.md
+++ b/app/posts/find-teacher-training/alpha/2017-10-10-alpha-version-2.md
@@ -1,9 +1,7 @@
 ---
 title: Alpha version 2
-description:
-tags:
+date: 2017-10-10
 ---
-
 [Version 2 prototype](https://search-and-compare-alpha.herokuapp.com/v02/)
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}

--- a/app/posts/find-teacher-training/alpha/2017-10-20-alpha-version-3.md
+++ b/app/posts/find-teacher-training/alpha/2017-10-20-alpha-version-3.md
@@ -1,9 +1,7 @@
 ---
 title: Alpha version 3
-description:
-tags:
+date: 2017-10-20
 ---
-
 [Version 3 prototype](https://search-and-compare-alpha.herokuapp.com/v03/)
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}

--- a/app/posts/find-teacher-training/alpha/2017-11-01-alpha-version-4.md
+++ b/app/posts/find-teacher-training/alpha/2017-11-01-alpha-version-4.md
@@ -1,9 +1,7 @@
 ---
 title: Alpha version 4
-description:
-tags:
+date: 2017-11-01
 ---
-
 [Version 4 prototype](https://search-and-compare-alpha.herokuapp.com/v04/)
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}

--- a/app/posts/find-teacher-training/alpha/2017-12-01-index.md
+++ b/app/posts/find-teacher-training/alpha/2017-12-01-index.md
@@ -2,7 +2,8 @@
 eleventyExcludeFromCollections: false
 layout: post
 title: Alpha
-description: Experimental designs
+description: Experimental designs.
+date: 2017-12-01
 related:
   items:
   - text: "Alpha prototype"

--- a/app/posts/find-teacher-training/private-beta/2018-04-12-user-research-apr-12.md
+++ b/app/posts/find-teacher-training/private-beta/2018-04-12-user-research-apr-12.md
@@ -1,9 +1,8 @@
 ---
 title: User research 12 April 2018
 description: Testing business studies flow with users interested in becoming a teacher, but not necessarily within business studies.
-tags:
+date: 2018-04-12
 ---
-
 Testing business studies flow with users interested in becoming a teacher, but not necessarily within business studies.
 
 * [Research summary](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/264339608/13th+Round+-+April+12th)

--- a/app/posts/find-teacher-training/private-beta/2018-04-25-user-research-apr-25.md
+++ b/app/posts/find-teacher-training/private-beta/2018-04-25-user-research-apr-25.md
@@ -1,9 +1,7 @@
 ---
 title: User research 25 April 2018
-description:
-tags:
+date: 2018-04-25
 ---
-
 Testing with users in the [middle of the digital inclusion scale](https://www.gov.uk/government/publications/government-digital-inclusion-strategy/government-digital-inclusion-strategy#annex-2-digital-inclusion-scale-for-individuals).
 
 * [Research summary](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/301596673/15th+Round+-+26th+April)

--- a/app/posts/find-teacher-training/private-beta/2018-05-01-private-beta-launch.md
+++ b/app/posts/find-teacher-training/private-beta/2018-05-01-private-beta-launch.md
@@ -1,7 +1,7 @@
 ---
 title: Private beta as launched
 description: The service as it was launched on 1 May 2018.
-tags:
+date: 2018-05-01
 ---
 [Tested with users on May 3](/find-teacher-training/private-beta/user-research-may-3), with key observations noted below.
 

--- a/app/posts/find-teacher-training/private-beta/2018-05-09-user-research-may-3.md
+++ b/app/posts/find-teacher-training/private-beta/2018-05-09-user-research-may-3.md
@@ -1,6 +1,7 @@
 ---
 title: User research 3 May 2018
 description: Testing with users middle to low on the digital inclusion scale, dyslexic and hearing impaired users.
+date: 2018-05-09
 tags: find-private-beta
 ---
 

--- a/app/posts/find-teacher-training/private-beta/2018-05-10-user-research-may-10.md
+++ b/app/posts/find-teacher-training/private-beta/2018-05-10-user-research-may-10.md
@@ -1,6 +1,7 @@
 ---
 title: User research 10 May 2018
 description: Testing with assisted digital, dyslexic and visually impaired users.
+date: 2018-05-10
 tags: find-private-beta
 ---
 

--- a/app/posts/find-teacher-training/private-beta/2018-05-15-index.md
+++ b/app/posts/find-teacher-training/private-beta/2018-05-15-index.md
@@ -3,6 +3,7 @@ eleventyExcludeFromCollections: false
 layout: post
 title: Private beta
 description: The private beta was a reduced version of the alpha, focusing on a single subject – business studies.
+date: 2018-05-15
 related:
   items:
   - text: "Private beta prototype"

--- a/app/posts/find-teacher-training/private-beta/2018-05-15-iteration-may-15.md
+++ b/app/posts/find-teacher-training/private-beta/2018-05-15-iteration-may-15.md
@@ -1,6 +1,7 @@
 ---
 title: Iteration 15 May 2018
 description: Updated ‘choose your search’ page and added subject filter to results.
+date: 2018-05-15
 tags: find-private-beta
 ---
 {% from "screenshots/macro.njk" import appScreenshots with context %}

--- a/app/posts/manage-teacher-training-applications/2019-02-19-first-designs.md
+++ b/app/posts/manage-teacher-training-applications/2019-02-19-first-designs.md
@@ -1,6 +1,7 @@
 ---
 title: First designs for a minimum viable service
 description: A minimum viable service that could allow the providers to access and manage their ITT applications.
+date: 2019-02-19
 related:
   items:
   - text: Confluence documentation

--- a/app/posts/manage-teacher-training-applications/2019-02-21-fewer-statuses.md
+++ b/app/posts/manage-teacher-training-applications/2019-02-21-fewer-statuses.md
@@ -1,6 +1,7 @@
 ---
 title: Fewer statuses
 description: Trying a smaller set of statuses.
+date: 2019-02-21
 related:
   items:
   - text: Confluence documentation

--- a/app/posts/manage-teacher-training-applications/2019-09-04-august-2019.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-04-august-2019.md
@@ -1,6 +1,7 @@
 ---
 title: New panels and application tables
-description: Bring 2018 version inline with design system
+description: Bring 2018 version inline with design system.
+date: 2019-09-04
 ---
 An update on the [2018 prototype](/manage-teacher-training-applications/fewer-statuses), bringing the design inline with the [GOV.UK Design System](https://design-system.service.gov.uk/).
 

--- a/app/posts/manage-teacher-training-applications/2019-09-18-application-states.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-18-application-states.md
@@ -1,6 +1,7 @@
 ---
 title: Application states
 description: Create new states with filters.
+date: 2019-09-18
 ---
 [Pull request](https://github.com/DFE-Digital/manage-teacher-training-applications-prototype/pull/2)
 

--- a/app/posts/manage-teacher-training-applications/2019-09-18-make-an-offer.md
+++ b/app/posts/manage-teacher-training-applications/2019-09-18-make-an-offer.md
@@ -1,6 +1,7 @@
 ---
 title: Make an offer
 description: First pass at making a conditional or unconditional offer.
+date: 2019-09-18
 ---
 A simple flow to allow providers to change status and make an offer to a candidate.
 

--- a/app/posts/manage-teacher-training-applications/2019-10-15-minimal-ui.md
+++ b/app/posts/manage-teacher-training-applications/2019-10-15-minimal-ui.md
@@ -1,6 +1,7 @@
 ---
 title: An interface for minimal service provision
 description: Looking towards rolling out the pilot.
+date: 2019-10-15
 ---
 Based on research findings from testing earlier versions of the prototype, and having determined the need for a minimal service for managing applications even at the very start of the pilot with SCITTs, we created an updated and stripped-down version of the interface.
 

--- a/app/posts/manage-teacher-training-applications/2019-12-02-as-launched-26-nov-2019.md
+++ b/app/posts/manage-teacher-training-applications/2019-12-02-as-launched-26-nov-2019.md
@@ -1,6 +1,7 @@
 ---
 title: As launched on 26 November 2019
-description: List applications, make offer or reject
+description: List applications, make offer or reject.
+date: 2019-12-02
 ---
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({

--- a/app/posts/publish-teacher-training-courses/2018-05-10-new-course-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-10-new-course-wizard.md
@@ -1,6 +1,7 @@
 ---
 title: Experimental new course wizard
 description: Breaking down data required for each course into a page-per-thing wizard.
+date: 2018-05-10
 ---
 First attempts at a ‘one thing per page’ approach to creating a course.
 

--- a/app/posts/publish-teacher-training-courses/2018-05-15-course-with-parts.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-15-course-with-parts.md
@@ -1,6 +1,7 @@
 ---
 title: Course with parts
 description: Experimental designs looking at breaking course fields onto different pages, based on a theme.
+date: 2018-05-15
 ---
 Experimental designs looking at breaking course fields onto different pages, based on a theme.
 

--- a/app/posts/publish-teacher-training-courses/2018-05-15-original-onboarding.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-15-original-onboarding.md
@@ -1,6 +1,7 @@
 ---
 title: Original onboarding
 description: The spreadsheet sent to providers rendered as a single page form.
+date: 2018-05-15
 ---
 The spreadsheet sent to providers rendered as a single page form. See the [original spreadsheet on confluence](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/319258638/Spreadsheet+for+private+beta).
 

--- a/app/posts/publish-teacher-training-courses/2018-05-22-courses-and-tabs.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-22-courses-and-tabs.md
@@ -1,6 +1,7 @@
 ---
 title: Courses and tabs
 description: Exploration of a home page view with tabs for courses, schools, default course and organisation details.
+date: 2018-05-22
 ---
 This is a visualisation of course information structured by:
 

--- a/app/posts/publish-teacher-training-courses/2018-05-24-what-is-a-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-24-what-is-a-course.md
@@ -1,6 +1,7 @@
 ---
 title: What is a course?
 description: Work to define our definition of a course.
+date: 2018-05-24
 ---
 * [Slide deck](https://docs.google.com/presentation/d/1QgjOu_xpzZGDP_ylMIKzDL8CgW1TvtVKICb0P8YiTWQ/edit?usp=sharing)
 * [BATSA-287](https://dfedigital.atlassian.net/browse/BATSA-287)

--- a/app/posts/publish-teacher-training-courses/2018-05-25-course-with-variants.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-25-course-with-variants.md
@@ -1,6 +1,7 @@
 ---
 title: Course with variants and field guidance
 description: Exploration of a course page with fields to capture variants of a course and the differences between them.
+date: 2018-05-25
 ---
 Exploration of a course page with fields to capture variants of a course and the differences between them.
 

--- a/app/posts/publish-teacher-training-courses/2018-05-25-imported-from-ucas.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-25-imported-from-ucas.md
@@ -1,6 +1,7 @@
 ---
 title: Course folding and UCAS course details
 description: Following the definition of a course, documentation on how we might fold courses based on UCAS data.
+date: 2018-05-25
 ---
 ## Course content we will receive in a feed from UCAS
 

--- a/app/posts/publish-teacher-training-courses/2018-05-31-sign-in-pre-register-user.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-31-sign-in-pre-register-user.md
@@ -1,6 +1,7 @@
 ---
 title: "Sign-in: Invite a user"
-description: This is the approach we attempted first. Because of limitations with the invite email and users ending up at a dead-end, we switched to self-registration
+description: This is the approach we attempted first. Because of limitations with the invite email and users ending up at a dead-end, we switched to self-registration.
+date: 2018-05-31
 ---
 The full journey from admin screens to a user completing sign up.
 

--- a/app/posts/publish-teacher-training-courses/2018-05-31-sign-in-self-serve-registration.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-31-sign-in-self-serve-registration.md
@@ -1,6 +1,7 @@
 ---
 title: "Sign-in: User registers themself"
 description: We send users a sign-up link so they can register and then be forwarded on to our service.
+date: 2018-05-31
 ---
 We send users a sign-up link so they can register and then be forwarded on to our service.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-01-course-field-guidance.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-01-course-field-guidance.md
@@ -1,6 +1,7 @@
 ---
 title: Contextual guidance on course fields
 description: A first pass at providing some guidance for each course field. Starting from the original onboarding guidance.
+date: 2018-06-01
 ---
 A first pass at providing some guidance for each course field. Starting from the original onboarding guidance.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-01-details-from-ucas.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-01-details-from-ucas.md
@@ -1,6 +1,7 @@
 ---
 title: Show details from UCAS
 description: Indicate the raw information we’ve received from UCAS, begin to explain where this must be edited and how we are handling that information.
+date: 2018-06-01
 ---
 Indicate the raw information we’ve received from UCAS, begin to explain where this must be edited and how we are handling that information.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-04-simplified-university-view.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-04-simplified-university-view.md
@@ -1,6 +1,7 @@
 ---
 title: A university’s view
 description: Universities are the simplest provider. There are no schools to apply to and no course folding.
+date: 2018-06-04
 ---
 Universities are the simplest provider. There are no schools to apply to and [no course folding](/publish-teacher-training-courses/imported-from-ucas).
 

--- a/app/posts/publish-teacher-training-courses/2018-06-06-school-direct-view.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-06-school-direct-view.md
@@ -1,6 +1,7 @@
 ---
 title: School direct view
 description: School Direct routes are the most complex. List schools, show multiple UCAS courses per subject, show folded course summary.
+date: 2018-06-06
 ---
 School Direct routes are the most complex. List schools, show multiple UCAS courses per subject, show folded course summary.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-11-kingston-school-direct.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-11-kingston-school-direct.md
@@ -1,58 +1,46 @@
 ---
 title: School direct view – Iteration
 description: An iteration of the school direct view tested with Kingston School Direct.
+date: 2018-06-11
 ---
-
 An iteration of the [school direct view](/publish-teacher-training-courses/school-direct-view) tested with Kingston School Direct.
 
 [Research video](https://lookback.io/watch/FoHoHPQF7B5TwrFkw)
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
-  items: [
-    {
-      text: "Courses",
-      img: { src: "courses.png" }
-    },
-    {
-      text: "Course",
-      img: { src: "course.png" }
-    },
-    {
-      text: "Course details from ucas",
-      img: { src: "course-details-from-ucas.png" }
-    },
-    {
-      text: "About this course",
-      img: { src: "about-this-course.png" }
-    },
-    {
-      text: "About this training provider",
-      img: { src: "about-this-training-provider.png" }
-    },
-    {
-      text: "Course requirements",
-      img: { src: "course-requirements.png" }
-    },
-    {
-      text: "Qualification",
-      img: { src: "qualification.png" }
-    },
-    {
-      text: "Salary",
-      img: { src: "salary.png" }
-    },
-    {
-      text: "Preview",
-      img: { src: "preview.png" }
-    },
-    {
-      text: "Schools",
-      img: { src: "schools.png" }
-    },
-    {
-      text: "Organisation",
-      img: { src: "organisation.png" }
-    }
-  ]
+  items: [{
+    text: "Courses",
+    img: { src: "courses.png" }
+  }, {
+    text: "Course",
+    img: { src: "course.png" }
+  }, {
+    text: "Course details from ucas",
+    img: { src: "course-details-from-ucas.png" }
+  }, {
+    text: "About this course",
+    img: { src: "about-this-course.png" }
+  }, {
+    text: "About this training provider",
+    img: { src: "about-this-training-provider.png" }
+  }, {
+    text: "Course requirements",
+    img: { src: "course-requirements.png" }
+  }, {
+    text: "Qualification",
+    img: { src: "qualification.png" }
+  }, {
+    text: "Salary",
+    img: { src: "salary.png" }
+  }, {
+    text: "Preview",
+    img: { src: "preview.png" }
+  }, {
+    text: "Schools",
+    img: { src: "schools.png" }
+  }, {
+    text: "Organisation",
+    img: { src: "organisation.png" }
+  }]
 }) }}

--- a/app/posts/publish-teacher-training-courses/2018-06-11-qa-draft.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-11-qa-draft.md
@@ -1,6 +1,7 @@
 ---
 title: Draft of the QA process
-description: Submit to QA and example pass and fail emails
+description: Submit to QA and example pass and fail emails.
+date: 2018-06-11
 ---
 An initial look at the process of sending a course to DfE for review, and examples of the responses providers might receive back.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-11-read-only.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-11-read-only.md
@@ -1,6 +1,7 @@
 ---
 title: Draft of a read only version
 description: An initial pass at what a read only view of the service could have looked like.
+date: 2018-06-11
 ---
 As part of preparing providers for the upcoming service we wanted to give them read-only access to the service so they could see what information was needed and begin writing their content.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-26-iteration-june-26.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-26-iteration-june-26.md
@@ -1,6 +1,7 @@
 ---
 title: Iteration 26 June 2018
 description: Separate courses by accrediting provider. Provide explicit fields for each course offered.
+date: 2018-06-26
 ---
 Following [user research with providers](/publish-teacher-training-courses/school-direct-view), it was found that the “About this course” field was confusing when it could potentially apply to different course variants.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-28-check-ucas-data.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-28-check-ucas-data.md
@@ -1,6 +1,7 @@
 ---
 title: Check your UCAS data (Initial launch)
 description: A read-only version of the tool where users can validate their imported courses and request access for users.
+date: 2018-06-28
 ---
 When onboarding users to the publish courses tool, to begin with they’ll only have access to the data we’ve imported from UCAS.
 

--- a/app/posts/publish-teacher-training-courses/2018-06-28-iteration-june-28.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-28-iteration-june-28.md
@@ -1,6 +1,7 @@
 ---
 title: Iteration 28 June 2018
 description: Add character counts and refine preview.
+date: 2018-06-28
 ---
 As with the [previous iteration](/publish-teacher-training-courses/iteration-june-26), we ran an unmoderated research session with this design where we asked providers to complete a course listing, the user recorded their input to a [session on Lookback](https://lookback.io/watch/ACpaee3SkiuGxS5CD).
 

--- a/app/posts/publish-teacher-training-courses/2018-06-29-request-access-iteration-june-29.md
+++ b/app/posts/publish-teacher-training-courses/2018-06-29-request-access-iteration-june-29.md
@@ -1,6 +1,7 @@
 ---
 title: Request access
 description: Request access for users.
+date: 2018-06-29
 ---
 A small iteration on the [initial design](/publish-teacher-training-courses/check-ucas-data#request-access) adding a form legend, the new user’s organisation and success message.
 

--- a/app/posts/publish-teacher-training-courses/2018-07-02-multiple-organisations.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-02-multiple-organisations.md
@@ -1,6 +1,7 @@
 ---
 title: Managing multiple organisations
 description: Some users will be responsible for courses from multiple organisations. eg SCITT-schools.
+date: 2018-07-02
 ---
 The way DfE models organisations is different to the way they’ve been modelled in UCAS. Some users will have access to multiple UCAS institutions.
 

--- a/app/posts/publish-teacher-training-courses/2018-07-03-about-your-organisation.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-03-about-your-organisation.md
@@ -1,6 +1,7 @@
 ---
 title: Shared organisation details
 description: Share organisation information between courses and split the organisation page across tabs.
+date: 2018-07-03
 ---
 The ‘About your organisation’ section is not unique to a course ([see old design](/publish-teacher-training-courses/iteration-june-28#course)). The data is about the organisation itself. Represent this by moving the fields out of course pages and up to the organisation view.
 

--- a/app/posts/publish-teacher-training-courses/2018-07-05-templates.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-05-templates.md
@@ -1,6 +1,7 @@
 ---
 title: Templates
 description: Use templates to share information between courses.
+date: 2018-07-05
 ---
 A first pass at providing users with a template function.
 

--- a/app/posts/publish-teacher-training-courses/2018-07-13-no-known-organisation.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-13-no-known-organisation.md
@@ -1,6 +1,7 @@
 ---
 title: When a user isn’t recognised
 description: Designs for when a user’s email isn’t in our whitelist.
+date: 2018-07-13
 ---
 If a user signs up who isn’t on our whitelist we don’t know much about them. We can’t give them access to anyone’s courses. We need to know which organisation they should be part of and then validate that.
 

--- a/app/posts/publish-teacher-training-courses/2018-07-16-salary-and-fees.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-16-salary-and-fees.md
@@ -1,6 +1,7 @@
 ---
 title: Salary and fees
 description: Designs for different fields for salaried and fee paying courses.
+date: 2018-07-16
 ---
 Fee paying courses need to have some different fields to salaried courses. Courses offering a salary typically don’t have any course fees (though some courses may have top-up fees for the PGCE aspect of a course) – for these courses we shouldn’t be asking for course fees. ([Example of the problem](/publish-teacher-training-courses/templates#dont-use-a-template))
 

--- a/app/posts/publish-teacher-training-courses/2018-07-20-ucas-course-status.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-20-ucas-course-status.md
@@ -1,6 +1,7 @@
 ---
 title: UCAS course status
 description: An iteration on the onboarding design (read-only) to include course status.
+date: 2018-07-20
 ---
 We show all UCAS courses rather than just the published ones. This means we are displaying courses that should go live but also those which have been suspended. Users need to see the status of their courses so they know what will be shown to candidates. The status needs to match the UCAS status.
 

--- a/app/posts/publish-teacher-training-courses/2018-07-31-validating-on-publish.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-31-validating-on-publish.md
@@ -1,6 +1,7 @@
 ---
 title: Validating on publish
 description: How validation works when a user tries to publish without the required fields.
+date: 2018-07-31
 ---
 Users need to save without all required fields being present so they’re not obstructed when completing their course listing. We’ve observed users filling them in piecemeal. For example, they may require information from an accrediting provider, or if they’re copying content from their previous UCAS listings or course website – they may not have existing text for one of the new fields, a field they plan to come back to. Leaving a field blank is preferable and less error prone than forcing them to enter ‘TBC’ or something similar.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-01-story-map-aug-1.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-01-story-map-aug-1.md
@@ -1,6 +1,7 @@
 ---
 title: Story map – 1 August 2018
 description: Screenshots of the end to end journey from publish courses to search and compare.
+date: 2018-08-01
 ---
 Designs illustrating each column in the [Trello Story map](https://trello.com/b/9fCxMchD/bat-search-story-map).
 

--- a/app/posts/publish-teacher-training-courses/2018-08-03-course-not-running.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-03-course-not-running.md
@@ -1,6 +1,7 @@
 ---
 title: Course statuses – 3 August iteration
 description: A more indepth look at UCAS course status and how it’ll affect publishing.
+date: 2018-08-03
 ---
 As a user looking at all of my courses imported from UCAS, I need to know which of those courses have been published, so that I know which courses applicants are seeing.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-07-success-messaging.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-07-success-messaging.md
@@ -1,6 +1,7 @@
 ---
 title: Success messaging
 description: Messages we show after a successful save or publish.
+date: 2018-08-07
 ---
 Designs for success messages shown after a successful save or publish.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-09-no-more-folding.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-09-no-more-folding.md
@@ -1,6 +1,7 @@
 ---
 title: No more course folding
 description: Reasoning behind not folding courses and unfolded course designs.
+date: 2018-08-09
 ---
 We defined folding as the combination of ‘course variants’ by subject, eg PGCE with QTS, QTS only, salaried and unsalaried would all show as one search result and course detail page.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-14-formatting.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-14-formatting.md
@@ -1,6 +1,7 @@
 ---
 title: Formatting
 description: Paragraphs, lists and links.
+date: 2018-08-14
 ---
 From user research we’ve found that users need to format their text using paragraphs, lists and links.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-17-copy-content-from-another-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-17-copy-content-from-another-course.md
@@ -1,6 +1,7 @@
 ---
 title: Copy content from another course
-description: Design for copying form values from one course to another
+description: Design for copying form values from one course to another.
+date: 2018-08-17
 ---
 ## We tried templates
 

--- a/app/posts/publish-teacher-training-courses/2018-08-17-needs-behind-fields.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-17-needs-behind-fields.md
@@ -1,6 +1,7 @@
 ---
 title: Fields we ask for and why
-description: Documentation of needs around each course field
+description: Documentation of needs around each course field.
+date: 2018-08-17
 ---
 Courses are divided across 3 parts to make them easier to complete:
 

--- a/app/posts/publish-teacher-training-courses/2018-08-17-terms-agreement.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-17-terms-agreement.md
@@ -1,6 +1,7 @@
 ---
 title: Terms agreement
 description: A user must agree to terms before enriching.
+date: 2018-08-17
 ---
 Before each user can begin enriching their course data we need them to agree to our terms and conditions.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-19-preview-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-19-preview-course.md
@@ -1,6 +1,7 @@
 ---
 title: Preview course
 description: Different preview states depending on course type and state.
+date: 2018-08-19
 ---
 Screenshots showing different preview states based on type and completeness of course.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-20-who-did-what-when.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-20-who-did-what-when.md
@@ -1,6 +1,7 @@
 ---
 title: Who did what and when
 description: The beginnings of an audit trail for content.
+date: 2018-08-20
 ---
 These are the beginnings of an audit trail for content. We will record the most recent author and publisher, and the times these events happen.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-23-user-research-aug-22.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-23-user-research-aug-22.md
@@ -1,6 +1,7 @@
 ---
 title: User research – 22 August
-description: Testing markdown, SimpleMDE and publishing workflow
+description: Testing markdown, SimpleMDE and publishing workflow.
+date: 2018-08-23
 ---
 In August we’ve struggled to find providers to test with, because schools are on holiday and universities are very busy.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-24-iteration-aug-23.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-24-iteration-aug-23.md
@@ -1,6 +1,7 @@
 ---
 title: Iteration – 23 August
-description: Trying to bring ‘About your organisation’ into the user journey
+description: Trying to bring ‘About your organisation’ into the user journey.
+date: 2018-08-24
 ---
 In this iteration we:
 

--- a/app/posts/publish-teacher-training-courses/2018-08-24-organisation-iteration-aug-24.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-24-organisation-iteration-aug-24.md
@@ -1,6 +1,7 @@
 ---
 title: Iteration – 24 August
-description: Split homepage into tasks, Step 1 and Step 2
+description: Split homepage into tasks, Step 1 and Step 2.
+date: 2018-08-24
 ---
 The [previous iteration](/publish-teacher-training-courses/iteration-aug-23) which placed a new emphasis on ‘About your organisation’ on the homepage tested well.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-29-contact-details.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-29-contact-details.md
@@ -1,6 +1,7 @@
 ---
 title: Contact details
-description: Allow users to edit their contact details
+description: Allow users to edit their contact details.
+date: 2018-08-29
 ---
 We added the [contact details from UCAS](/publish-teacher-training-courses/iteration-aug-23#about-your-organisation) to the design ([Trello](https://trello.com/c/XcWDGsvo/175-design-showing-org-info-to-publishers)). In user research we asked training providers about those details. We expected to be able to display them to applicants. We thought this was something we could avoid building for the minimum viable service.
 

--- a/app/posts/publish-teacher-training-courses/2018-09-10-enrichment-sept-6.md
+++ b/app/posts/publish-teacher-training-courses/2018-09-10-enrichment-sept-6.md
@@ -1,6 +1,7 @@
 ---
 title: Enrichment release – 6 September
 description: Publish courses, as it was released with the course enrichment feature.
+date: 2018-09-10
 ---
 Screenshots of Publish courses (manage-courses-ui) as released on 6 September.
 

--- a/app/posts/publish-teacher-training-courses/2018-09-11-welcome-email.md
+++ b/app/posts/publish-teacher-training-courses/2018-09-11-welcome-email.md
@@ -1,6 +1,7 @@
 ---
 title: Welcome email
 description: The email we send when users first log in.
+date: 2018-09-11
 ---
 This is the email we send to users when they log in for the first time.
 

--- a/app/posts/publish-teacher-training-courses/2018-09-12-copy-content-from-another-course-live.md
+++ b/app/posts/publish-teacher-training-courses/2018-09-12-copy-content-from-another-course-live.md
@@ -1,6 +1,7 @@
 ---
 title: Copy content from another course (Live)
 description: We changed this feature when we built it.
+date: 2018-09-12
 ---
 When we initially designed and tested the [copy content feature](/publish-teacher-training-courses/copy-content-from-another-course) we expected the backend to be a bottleneck:
 

--- a/app/posts/publish-teacher-training-courses/2018-09-14-copy-content-from-another-course-14-sept.md
+++ b/app/posts/publish-teacher-training-courses/2018-09-14-copy-content-from-another-course-14-sept.md
@@ -1,6 +1,7 @@
 ---
 title: Copy content – 14 September iteration
 description: Make the copy feature easier to find.
+date: 2018-09-14
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({ text: "We didn’t build this design. Instead we used an MVP ‘you can find copy here’ – ie a signpost where people were looking for the feature.", iconFallbackText: "Warning" }) }}

--- a/app/posts/publish-teacher-training-courses/2018-10-15-course-not-running-oct-15.md
+++ b/app/posts/publish-teacher-training-courses/2018-10-15-course-not-running-oct-15.md
@@ -1,6 +1,7 @@
 ---
 title: Course statuses – 15 October iteration
 description: We have uncovered more complexity around course statuses on UCAS.
+date: 2018-10-15
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({ text: "We didn’t build this design.", iconFallbackText: "Warning" }) }}

--- a/app/posts/publish-teacher-training-courses/2018-10-18-choose-outcome.md
+++ b/app/posts/publish-teacher-training-courses/2018-10-18-choose-outcome.md
@@ -1,6 +1,7 @@
 ---
 title: Edit a course outcome
 description: Allow providers to choose an outcome, instead of using our inferred one.
+date: 2018-10-18
 ---
 We currently infer the outcome with a mapping from UCAS data:
 

--- a/app/posts/publish-teacher-training-courses/2018-11-01-hide-discontinued-locations.md
+++ b/app/posts/publish-teacher-training-courses/2018-11-01-hide-discontinued-locations.md
@@ -1,6 +1,7 @@
 ---
 title: Hide discontinued training locations
 description: Don’t show these locations to avoid confusion.
+date: 2018-11-01
 ---
 The way we display non-running training locations in Publish has confused some publishers (we’ve received Zendesk tickets about superfluous training locations on their courses, where the publisher didn’t understand that the location was discontinued and they didn’t need to do anything).
 

--- a/app/posts/publish-teacher-training-courses/2018-11-06-the-location-problem.md
+++ b/app/posts/publish-teacher-training-courses/2018-11-06-the-location-problem.md
@@ -1,6 +1,7 @@
 ---
 title: The location problem
 description: Location is a complex issue, we begin to break it down.
+date: 2018-11-06
 ---
 We know that different providers treat location differently. A provider might:
 

--- a/app/posts/publish-teacher-training-courses/2018-11-16-location-research.md
+++ b/app/posts/publish-teacher-training-courses/2018-11-16-location-research.md
@@ -1,6 +1,7 @@
 ---
 title: Location labels and survey research
 description: First attempts to understand location with a classification exercise.
+date: 2018-11-16
 ---
 Following research on maps with candidates and [discussions with providers about location](/publish-teacher-training-courses/the-location-problem), we sought to focus further research by providing prototypes.
 

--- a/app/posts/publish-teacher-training-courses/2018-11-27-schools-autocomplete.md
+++ b/app/posts/publish-teacher-training-courses/2018-11-27-schools-autocomplete.md
@@ -1,6 +1,7 @@
 ---
 title: Schools autocomplete
 description: An autocomplete for selecting partner schools quickly.
+date: 2018-11-27
 ---
 [Live demo](https://manage-courses-prototype.herokuapp.com/school-autocomplete) and [pull request](https://github.com/DFE-Digital/manage-courses-prototype/pull/18).
 

--- a/app/posts/publish-teacher-training-courses/2018-11-30-ucas-onboarding-form.md
+++ b/app/posts/publish-teacher-training-courses/2018-11-30-ucas-onboarding-form.md
@@ -1,6 +1,7 @@
 ---
 title: UCAS onboarding form
 description: The form completed by new training providers when they begin offering initial teacher training courses.
+date: 2018-11-30
 ---
 The form completed by new training providers when they begin offering initial teacher training courses.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard
 description: Create a new course in Publish rather than UCAS.
+date: 2018-12-14
 ---
 As part of the [UCAS Transition work](https://docs.google.com/document/d/1H8ecdKnrJ2nJbc87Lgx5t-gx2_jnt0NLYLKf1Y_G9zg/edit#) ([Trello story map](https://trello.com/b/O0RjGYkw/ucas-transition-story-map)) we need to bring course creation into Publish. We [looked at this briefly in May](/publish-teacher-training-courses/new-course-wizard) before we knew we’d have UCAS data.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-15-new-course-2.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-15-new-course-2.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard – 6 December iteration
 description: Consider route into and out of wizard.
+date: 2018-12-15
 ---
 This design [tweaks the previous wizard](/publish-teacher-training-courses/new-course) so that:
 

--- a/app/posts/publish-teacher-training-courses/2018-12-16-new-course-locations.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-16-new-course-locations.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard – Training locations
 description: Choosing training locations from the new course wizard.
+date: 2018-12-16
 ---
 For providers with multiple training locations we need to ask them which of those locations the course will be running at. Otherwise we can default to their only location.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-17-specific-requirements.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-17-specific-requirements.md
@@ -1,6 +1,7 @@
 ---
 title: Specific course requirements for UCAS Apply
 description: Documentation on minimum qualifications settings in UCAS web-link and apply.
+date: 2018-12-17
 ---
 Providers can set specific requirements for their courses when setting up or editing their training programmes in UCAS web-link.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-18-minimum-course-requirements.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-18-minimum-course-requirements.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard – Minimum course requirements
 description: Choose the minimum course requirements from the new course wizard.
+date: 2018-12-18
 ---
 Following on from the [investigation into UCAS specific course requirements](/publish-teacher-training-courses/specific-requirements), a design that comes towards the end of the new course wizard.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-19-edit-title.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-19-edit-title.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard – Confirming course title
 description: Moving the course title fields into the wizard.
+date: 2018-12-19
 ---
 An iteration on [the initial design](/publish-teacher-training-courses/new-course-2#customise-title) which:
 

--- a/app/posts/publish-teacher-training-courses/2018-12-20-publish-states.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-20-publish-states.md
@@ -2,6 +2,7 @@
 layout: page
 title: Rethinking the publish workflow
 description: What does the publish workflow look like after UCAS transition?
+date: 2018-12-20
 ---
 Publishing before transition was complicated. Each training location had a state and a publish flag, which determines if the course appears in Find and can be applied to on UCAS Apply. Then the content has its own state – Empty, Draft or Published.
 

--- a/app/posts/publish-teacher-training-courses/2018-12-21-vacancies.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-21-vacancies.md
@@ -1,6 +1,7 @@
 ---
 title: Vacancies
 description: First design for changing vacancies at each training location on a course.
+date: 2018-12-21
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({

--- a/app/posts/publish-teacher-training-courses/2019-01-10-migrating-publish-statuses.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-10-migrating-publish-statuses.md
@@ -2,6 +2,7 @@
 layout: page
 title: Migrating publish statuses
 description: How old UCAS status and enrichment status should map to a single new status.
+date: 2019-01-10
 ---
 How we get from the two statuses we have now (UCAS course running status, and Publish course content status), to a [simpler single course status](/publish-teacher-training-courses/publish-states).
 

--- a/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
@@ -1,6 +1,7 @@
 ---
 title: Course page – 11 January iteration
 description: Edit course information, update the status column.
+date: 2019-01-11
 ---
 An iteration on the [current course page](/publish-teacher-training-courses/enrichment-sept-6#course) which:
 

--- a/app/posts/publish-teacher-training-courses/2019-01-14-new-course-iteration-14-jan.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-14-new-course-iteration-14-jan.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard – 14 January iteration
 description: Updates to subjects, minimum requirements and course titles.
+date: 2019-01-14
 ---
 In this iteration we changed:
 

--- a/app/posts/publish-teacher-training-courses/2019-01-14-vacancies-iteration-14-jan.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-14-vacancies-iteration-14-jan.md
@@ -1,6 +1,7 @@
 ---
 title: Vacancies – 14 January iteration
 description: Updates to button styles, messaging and validation.
+date: 2019-01-14
 ---
 An iteration on [an earlier design](/publish-teacher-training-courses/vacancies).
 

--- a/app/posts/publish-teacher-training-courses/2019-01-28-new-further-education-course.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-28-new-further-education-course.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard – Further education
 description: Designs for the further education path in the new course wizard.
+date: 2019-01-28
 ---
 After selecting ‘Further education’ as a course type, the wizard goes down a different path.
 

--- a/app/posts/publish-teacher-training-courses/2019-01-29-edit-course-workflow.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-29-edit-course-workflow.md
@@ -1,6 +1,7 @@
 ---
 title: Edit course information workflow
 description: Workflow diagram for editing course information.
+date: 2019-01-29
 ---
 From the course summary page, where answers to questions are listed ([check your answers](/publish-teacher-training-courses/new-course-iteration-14-jan#check-your-answers), [change course information](/publish-teacher-training-courses/new-course-iteration-14-jan#change-course-information)), users expect to edit one answer then return to this page.
 

--- a/app/posts/publish-teacher-training-courses/2019-01-30-preparing-for-locations.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-30-preparing-for-locations.md
@@ -1,6 +1,7 @@
 ---
 title: Preparing for more features
 description: Updating the organisation and courses pages to accommodate new features being added as part of UCAS transition.
+date: 2019-01-30
 ---
 A redesign of the organisation page to accommodate new things that providers can do.
 

--- a/app/posts/publish-teacher-training-courses/2019-01-31-new-training-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-31-new-training-location.md
@@ -1,6 +1,7 @@
 ---
 title: Add training location wizard
 description: Add a training location in Publish rather than UCAS.
+date: 2019-01-31
 ---
 The first design for adding training locations to an organisation. It follows the same patterns as the [new course wizard](/publish-teacher-training-courses/new-course-iteration-14-jan) – one thing per page, check your answers at the end, back-and-forth editing once the wizard is finished.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-11-new-training-location-region.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-11-new-training-location-region.md
@@ -1,6 +1,7 @@
 ---
 title: Add a region or area workflow
 description: Add a region or area, rather than a school or university.
+date: 2019-02-11
 ---
 Following on from the [specific school or university](/publish-teacher-training-courses/new-training-location) workflow, this design builds out the ‘region’ training type.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-12-mvp-add-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-12-mvp-add-location.md
@@ -1,6 +1,7 @@
 ---
 title: Minimum viable Add training location
 description: A replication of what’s available on UCAS. For if we don’t have time to build school autocompletes and other features, with everything else.
+date: 2019-02-12
 ---
 A much simplified training location flow. It replicates what is available on UCAS, without any extras.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
@@ -1,6 +1,7 @@
 ---
 title: "New course wizard: Accredited body – 5 February iteration"
 description: Remove one of the choices, and minimise the chance of error.
+date: 2019-02-13
 ---
 The original choice between we are the accredited body versus another organisation is not a valid question. For School Direct they will always need an accredited body. For SCITTs and universities, they are accredited.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
@@ -1,6 +1,7 @@
 ---
 title: "New course wizard: Languages – 5 February iteration"
 description: Simplify the fields for languages.
+date: 2019-02-14
 ---
 Providers model their modern languages courses differently.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-15-status-logic-before-transition.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-15-status-logic-before-transition.md
@@ -1,6 +1,7 @@
 ---
 title: Status logic before UCAS transition
 description: How vacancies, applications and whether a course is on Find is derived from a set of training locations.
+date: 2019-02-15
 ---
 ## Training location: Is it on Find?
 

--- a/app/posts/publish-teacher-training-courses/2019-02-16-rollover-reckons.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-16-rollover-reckons.md
@@ -1,6 +1,7 @@
 ---
 title: Rollover reckons
 description: Thoughts on what rollover might look like. And notes on what rollover is right now.
+date: 2019-02-16
 ---
 ## UCAS rollover
 

--- a/app/posts/publish-teacher-training-courses/2019-02-17-mvp-add-location-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-17-mvp-add-location-iteration.md
@@ -1,6 +1,7 @@
 ---
 title: Add a location – 13 February iteration
 description: Clarify the purpose of locations.
+date: 2019-02-17
 ---
 The term ‘training locations’ is ambiguous.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-21-first-transition-comms.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-21-first-transition-comms.md
@@ -1,6 +1,7 @@
 ---
 title: Email announcing UCAS transition
 description: Sent on Monday 20 February.
+date: 2019-02-21
 ---
 {% set emailContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-02-21-rollover-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-21-rollover-wizard.md
@@ -1,6 +1,7 @@
 ---
 title: Rollover wizard
 description: A full rollover wizard, ending in a page with current and next cycles.
+date: 2019-02-21
 ---
 Following on from [rollover reckons](/publish-teacher-training-courses/rollover-reckons), this shows a full rollover wizard.
 

--- a/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
@@ -1,6 +1,7 @@
 ---
 title: Onboarding workflow and wizard
 description: How does the onboarding process look after UCAS transition?
+date: 2019-02-26
 ---
 ## Current process
 

--- a/app/posts/publish-teacher-training-courses/2019-02-27-ucas-apply-preferences.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-27-ucas-apply-preferences.md
@@ -1,6 +1,7 @@
 ---
 title: "UCAS Apply preferences"
 description: Settings such as GT12 letters, Star J, Star X and other requirements.
+date: 2019-02-27
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({

--- a/app/posts/publish-teacher-training-courses/2019-03-01-ucas-apply-preferences-2.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-01-ucas-apply-preferences-2.md
@@ -1,6 +1,7 @@
 ---
 title: "UCAS Apply preferences: Letters and alerts"
 description: Only the GT12 letter and email alert preferences are needed.
+date: 2019-03-01
 ---
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {{ govukWarningText({

--- a/app/posts/publish-teacher-training-courses/2019-03-05-postcodes.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-05-postcodes.md
@@ -1,6 +1,7 @@
 ---
 title: Postcodes
 description: Asking for, validating and storing postcodes.
+date: 2019-03-05
 ---
 We haven’t been validating postcodes in our contact addresses. This raises a few issues:
 

--- a/app/posts/publish-teacher-training-courses/2019-03-05-transition-explainer.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-05-transition-explainer.md
@@ -1,6 +1,7 @@
 ---
 title: Explaining transition
 description: A page transitioned organisations will see when they first log in.
+date: 2019-03-05
 ---
 We’re communicating UCAS transition by email. Not everyone will read their email, and some of the new features will not be immediately obvious. The journey on UCAS’s side may not be ideal – we can’t rely on updated messaging or redirects.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-08-email-transition-first-batch.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-08-email-transition-first-batch.md
@@ -1,6 +1,7 @@
 ---
 title: Email asking for providers who are available 15-18 April for our first UCAS transition group
 description: Sent on Thursday 7 March.
+date: 2019-03-08
 ---
 {% set emailContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-03-08-ucas-contacts.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-08-ucas-contacts.md
@@ -1,6 +1,7 @@
 ---
 title: UCAS settings and contacts
 description: Problems sharing contact information, and how we get around them.
+date: 2019-03-08
 ---
 An [update to the UCAS settings design](/publish-teacher-training-courses/ucas-apply-preferences-2) to include UCAS contacts.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-09-deleting-and-withdrawing.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-09-deleting-and-withdrawing.md
@@ -1,6 +1,7 @@
 ---
 title: Deleting and withdrawing courses
 description: And why there are both.
+date: 2019-03-09
 ---
 Deleting a course entirely removes it, it won’t be in the courses table. Providers can only delete courses that haven’t been published in this cycle. Deletions are soft – a developer should be able to restore a course that a provider deletes by mistake.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-13-second-transition-email.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-13-second-transition-email.md
@@ -1,6 +1,7 @@
 ---
 title: Email about Publish changes in April
 description: Sent on Wednesday 13 March.
+date: 2019-03-13
 ---
 {% set emailContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-03-15-requesting-a-title.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-15-requesting-a-title.md
@@ -1,8 +1,8 @@
 ---
 title: Requesting a title
 description: What happens when a provider asks for a custom title.
+date: 2019-03-15
 ---
-
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
   items: [{

--- a/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
@@ -1,6 +1,7 @@
 ---
 title: Tabs on course pages
 description: Splitting course details and enrichments.
+date: 2019-03-20
 ---
 An iteration on [the previous design](#old-course-design) where course details and enrichments were shown together.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-20-new-course-google-form.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-20-new-course-google-form.md
@@ -1,9 +1,8 @@
 ---
 title: New course wizard – As a Google Form
 description: An MVP version of the wizard we can ship with transition.
-tags:
+date: 2019-03-20
 ---
-
 We don’t expect to build the new course wizard in time for transition.
 
 As an MVP, and so that providers can still add courses when they need to, we’ve mirrored the wizard as a Google Form. We can ask the same questions and capture what we need, trigger a support request and then manually create what is asked for. Before rollover we expect new course volume to be small.

--- a/app/posts/publish-teacher-training-courses/2019-03-24-minimum-requirements-iterations.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-24-minimum-requirements-iterations.md
@@ -1,6 +1,7 @@
 ---
 title: Minimum course requirements – iterations
 description: A view of how the minimum requirements design has been iterated since December.
+date: 2019-03-24
 ---
 Progression of the minimum requirements page design:
 

--- a/app/posts/publish-teacher-training-courses/2019-03-25-age-ranges.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-25-age-ranges.md
@@ -1,6 +1,7 @@
 ---
 title: Age ranges
 description: Move age range from an optional question on the subject page to a required question on its own page.
+date: 2019-03-25
 ---
 Move age range from an optional question on the subject page to a required question on its own page.
 

--- a/app/posts/publish-teacher-training-courses/2019-03-26-new-location-google-form.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-26-new-location-google-form.md
@@ -1,6 +1,7 @@
 ---
 title: New location as a Google form
 description: An MVP version of the location form we can ship with transition.
+date: 2019-03-26
 ---
 Like [new courses](/publish-teacher-training-courses/new-course-google-form), we don’t expect to build the new location features in time for transition.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-02-first-transition-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-02-first-transition-mvp.md
@@ -1,6 +1,7 @@
 ---
 title: An MVP for the first cohort transition from UCAS
 description: A projected cut of the service and how it will look around the time we transition the first and second cohorts from UCAS.
+date: 2019-04-02
 ---
 A projected cut of the service and how it will look around the time we transition the first and second cohorts from UCAS.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-08-email-video-comms.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-08-email-video-comms.md
@@ -1,6 +1,7 @@
 ---
 title: Email with video of new vacancies feature
 description: Watch our video about the new Publish teacher training courses.
+date: 2019-04-08
 ---
 {% set videoContent %}
 Dear colleague,

--- a/app/posts/publish-teacher-training-courses/2019-04-09-new-course-wizard-iteration-9-apr.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-09-new-course-wizard-iteration-9-apr.md
@@ -1,6 +1,7 @@
 ---
 title: New course wizard – 9 April iteration
 description: Bring the wizard in line with changes made to the Google Form.
+date: 2019-04-09
 ---
 Bring the wizard in line with changes made to the Google Form:
 

--- a/app/posts/publish-teacher-training-courses/2019-04-14-problems-with-course.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-14-problems-with-course.md
@@ -1,6 +1,7 @@
 ---
 title: Problems with a course
 description: Exploration into highlighting problems with a course before publishing.
+date: 2019-04-14
 ---
 Exploration into highlighting problems with a course before publishing.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-15-mvp-type-of-location.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-mvp-type-of-location.md
@@ -1,6 +1,7 @@
 ---
 title: Type of location MVP
 description: A quick way to indicate if a location is an area or an address.
+date: 2019-04-15
 ---
 A quick way to indicate if a location is an area or an address.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-15-tabs-on-locations.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-15-tabs-on-locations.md
@@ -1,6 +1,7 @@
 ---
 title: Tabs on locations
 description: Show courses at each location and location history.
+date: 2019-04-15
 ---
 As part of work looking into how a location might be deleted or removed, it became clear that it was difficult to see which courses a location was assigned to.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
@@ -1,6 +1,7 @@
 ---
 title: Logic mapping UCAS eligibility questions to API codes
 description: Which code should the API sent to UCAS based on a provider’s answers to questions.
+date: 2019-04-16
 ---
 UCAS sets a status (1, 2, 3, 9 or n/a) for Maths, English and Science for each course. [This denotes who can apply](/publish-teacher-training-courses/specific-requirements).
 

--- a/app/posts/publish-teacher-training-courses/2019-04-17-onboarding-wizard-as-google-form.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-17-onboarding-wizard-as-google-form.md
@@ -1,6 +1,7 @@
 ---
 title: Onboarding wizard as a Google form
 description: Capturing contact details, UCAS admin details and first location.
+date: 2019-04-17
 ---
 An update on the [original onboarding wizard](/publish-teacher-training-courses/onboarding-wizard). This form is an accompaniment to an initial onboarding call, meaning we don’t have to ask and transcribe answers to these questions.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
@@ -2,6 +2,7 @@
 layout: page
 title: In what order should we build the Edit screens?
 description: List edit screens with their complexity and priority.
+date: 2019-04-19
 ---
 [Edit screen workflows in a Google Drawing](https://docs.google.com/drawings/d/1OrJYSTmRSJD2GEAWFnr2lXLNo7A9J9GDsPMQUm0Pi0M/edit) and the [new course flow](https://docs.google.com/drawings/d/1DAhz464j1XDyQPoOH0adIwAceUwuGU1rqsWkVn8ZQ8I/edit) for context.
 

--- a/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
@@ -2,6 +2,7 @@
 layout: page
 title: Publishing during rollover
 description: What does Publish do, what changes?
+date: 2019-04-22
 ---
 During rollover there are two cycles: the current cycle, and another that’s being prepared for the next cycle. Courses in the next cycle can’t go live until the cycle begins, which is usually in October.
 

--- a/app/posts/publish-teacher-training-courses/2019-05-14-shipped-for-transition.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-14-shipped-for-transition.md
@@ -1,6 +1,7 @@
 ---
 title: What we shipped for UCAS transition
 description: Locations, location editing and vacancies.
+date: 2019-05-14
 ---
 Based on our [transition MVP designs](/publish-teacher-training-courses/first-transition-mvp), when we transitioned all providers away from UCAS we’d shipped the following features:
 

--- a/app/posts/publish-teacher-training-courses/2019-05-20-support-for-missing-features.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-20-support-for-missing-features.md
@@ -1,6 +1,7 @@
 ---
 title: Support for missing features
 description: Filling the gap left by unbuilt features.
+date: 2019-05-20
 ---
 Because of the UCAS transition timescales [we’ve shipped without required features](/publish-teacher-training-courses/shipped-for-transition).
 

--- a/app/posts/publish-teacher-training-courses/2019-05-22-courses-as-an-accredited-body.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-22-courses-as-an-accredited-body.md
@@ -1,6 +1,7 @@
 ---
 title: Courses as an accredited body
 description: See which courses you’re the accredited body for.
+date: 2019-05-22
 ---
 There is a need for accredited bodies to see the courses they are associated with. UCAS web-link used to give them a read-only view of all courses – running or not, as well as a CSV export of the data.
 

--- a/app/posts/publish-teacher-training-courses/2019-05-31-access-to-multiple-organisations.md
+++ b/app/posts/publish-teacher-training-courses/2019-05-31-access-to-multiple-organisations.md
@@ -1,6 +1,7 @@
 ---
 title: Highlighting the multiple organisations feature
 description: Call out how to get access to more organisations.
+date: 2019-05-31
 ---
 Providers can already [manage multiple organisations from a single account](/publish-teacher-training-courses/multiple-organisations). But only providers who have this set up will know about this feature. There are users who don’t know they can do this who are using multiple logins to manage organisations.
 

--- a/app/posts/publish-teacher-training-courses/2019-06-10-minimum-requirements-read-only-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2019-06-10-minimum-requirements-read-only-mvp.md
@@ -1,6 +1,7 @@
 ---
 title: UCAS GCSE requirements – A read only MVP
 description: Show the codes and their meanings to ship earlier.
+date: 2019-06-10
 ---
 To implement the [full design](/publish-teacher-training-courses/minimum-course-requirements-logic) we need to fix the data and coerce the model into our representation. The stories are large and sequential.
 

--- a/app/posts/publish-teacher-training-courses/2019-08-06-allocations.md
+++ b/app/posts/publish-teacher-training-courses/2019-08-06-allocations.md
@@ -1,6 +1,7 @@
 ---
 title: Allocations
 description: Show the allocation policy on course detail pages.
+date: 2019-08-06
 ---
 {% set html %}
   <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><a href="https://docs.google.com/document/d/1926pN2UTaknKAC4bYUGyCSiPe5lBXJZ33ld7LXmftYw/edit">Original context</a></h4>

--- a/app/posts/publish-teacher-training-courses/2019-09-20-email-new-cycle.md
+++ b/app/posts/publish-teacher-training-courses/2019-09-20-email-new-cycle.md
@@ -1,6 +1,7 @@
 ---
 title: Emails for the new 2019/20 cycle
 description: Prompts and updates for providers.
+date: 2019-09-20
 ---
 In the lead up to the opening of the new recruitment cycle on 1 October 2019, we sent these emails.
 

--- a/app/posts/publish-teacher-training-courses/2019-10-15-what-we-did-for-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2019-10-15-what-we-did-for-rollover.md
@@ -1,6 +1,7 @@
 ---
 title: Rollover – what we did in 2019
 description: How we handled our first rollover period.
+date: 2019-10-15
 ---
 ## What is rollover?
 

--- a/app/posts/support-for-apply/2019-11-29-prototype-v1.md
+++ b/app/posts/support-for-apply/2019-11-29-prototype-v1.md
@@ -1,6 +1,7 @@
 ---
 title: Support for Apply as designed for MVP
-description: The initial pilot designs
+description: The initial pilot designs.
+date: 2019-11-29
 ---
 On 26 November we launched the initial Support for Apply pilot application to let support agents amend applications and import references submitted via Google Forms.
 

--- a/scripts/generate.js
+++ b/scripts/generate.js
@@ -20,6 +20,8 @@ const deepestDirectory = directoryName.split('/').pop()
 var title = deepestDirectory.replace(/-/g, ' ')
 title = title.charAt(0).toUpperCase() + title.slice(1)
 
+const datestamp = DateTime.local().toFormat('yyyy-MM-dd')
+
 const imageDirectory = `app/images/${directoryName}`
 const postDirectory = `app/posts/${directoryName}`.replace('/' + deepestDirectory, '')
 
@@ -73,6 +75,7 @@ function generatePage () {
   const templateStart = `---
 title: ${title}
 description:
+date: ${datestamp}
 ---
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
@@ -89,7 +92,7 @@ description:
     }`
   })
 
-  const filename = `${postDirectory}/${DateTime.local().toFormat('yyyy-MM-dd')}-${deepestDirectory}.md`
+  const filename = `${postDirectory}/${datestamp}-${deepestDirectory}.md`
 
   fs.writeFile(
     filename,

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -34,6 +34,8 @@ const deepestDirectory = directoryName.split('/').pop()
 var title = deepestDirectory.replace(/-/g, ' ')
 title = title.charAt(0).toUpperCase() + title.slice(1)
 
+const datestamp = DateTime.local().toFormat('yyyy-MM-dd')
+
 const imageDirectory = `app/images/${directoryName}`
 const postDirectory = `app/posts/${directoryName}`.replace('/' + deepestDirectory, '')
 
@@ -104,6 +106,7 @@ function generatePage () {
   const templateStart = `---
 title: ${title}
 description:
+date: ${datestamp}
 ---
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
@@ -121,7 +124,7 @@ description:
     }`
   })
 
-  const filename = `${postDirectory}/${DateTime.local().toFormat('yyyy-MM-dd')}-${deepestDirectory}.md`
+  const filename = `${postDirectory}/${datestamp}-${deepestDirectory}.md`
 
   fs.writeFile(
     filename,


### PR DESCRIPTION
11ty can derive a post’s publish date from its filename, however Netlify CMS cannot. It looks for a `date` field in the frontmatter. Without that, it assumes todays date, and if making changes, will add that date to a post. So… added a `date` field to all previous posts. Which was fun.

Also updated the generator scripts to include this field also.