### PR TITLE
Pull heading links outside of main content

### DIFF
--- a/app/_components/figure/template.njk
+++ b/app/_components/figure/template.njk
@@ -3,6 +3,9 @@
 <figure class="app-figure">
 {% if params.title %}
   <figcaption class="govuk-heading-m">
+    {% if params.id %}
+      <a class="header-anchor" href="#{{ params.id }}">#</a>
+    {% endif %}
     {{ params.title }}
   </figcaption>
 {% endif %}

--- a/app/_components/prose/_prose.scss
+++ b/app/_components/prose/_prose.scss
@@ -175,6 +175,8 @@
     font-style: italic;
     font-weight: normal;
     color: govuk-colour("mid-grey");
+    position: absolute;
+    margin-left: -1em;
 
     &:hover {
       color: $govuk-link-hover-colour;

--- a/app/_components/prose/_prose.scss
+++ b/app/_components/prose/_prose.scss
@@ -175,8 +175,13 @@
     font-style: italic;
     font-weight: normal;
     color: govuk-colour("mid-grey");
-    position: absolute;
-    margin-left: -1em;
+    margin-right: 0.1em;
+
+    @media (min-width: 1050px) {
+      position: absolute;
+      margin-left: -1em;
+      margin-right: 0;
+    }
 
     &:hover {
       color: $govuk-link-hover-colour;

--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -1,7 +1,10 @@
 {%- from "../figure/macro.njk" import appFigure with context -%}
 <section class="app-screenshots app-prose govuk-!-margin-top-9" id="screenshots">
   {% if not params.hideContents %}
-    <h2 class="govuk-heading-l app-!-print-display-none">Screenshots</h2>
+    <h2 class="govuk-heading-l app-!-print-display-none">
+      <a class="header-anchor" href="#screenshots">#</a>
+      Screenshots
+    </h2>
     <ul class="govuk-list app-screenshots__contents app-!-print-display-none">
       {% for item in params.items %}
         <li>
@@ -16,6 +19,7 @@
   {%- set alt = item.img.alt or ("Screenshot of " + item.text) -%}
   <div class="app-screenshots__screenshot" id="{{ id }}">
     {{ appFigure({
+      id: id,
       image: {
         path: params.path or item.img.path,
         file: file,

--- a/lib/libraries/markdown.js
+++ b/lib/libraries/markdown.js
@@ -14,7 +14,8 @@ module.exports = (() => {
     .use(require('markdown-it-abbr'))
     .use(require('markdown-it-anchor'), {
       permalink: true,
-      permalinkSymbol: '#'
+      permalinkSymbol: '#',
+      permalinkBefore: true
     })
     .use(require('markdown-it-deflist'))
     .use(require('markdown-it-footnote'))


### PR DESCRIPTION
Show them to the left of the heading and out of the document flow so that:
- They can help to scan through content
- They don't impede reading the content

Also adds heading links to screenshots.

## Wide screens

![Screen Shot 2020-01-31 at 13 22 06](https://user-images.githubusercontent.com/319055/73542498-bdb18900-442c-11ea-9398-9b22a8419a5a.png)

## Thin screens

![Screen Shot 2020-01-31 at 13 22 14](https://user-images.githubusercontent.com/319055/73542497-bdb18900-442c-11ea-89f0-59e2b4a8ed47.png)