### PR TITLE
Use forked version of webshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "rollup": "^1.29.1",
     "rollup-plugin-node-builtins": "^2.1.2",
     "sharp": "^0.23.4",
-    "webshot": "^0.18.0"
+    "webshot-node": "^0.18.2"
   },
   "devDependencies": {
     "standard": "^14.3.1"

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -22,7 +22,7 @@ const { DateTime } = require('luxon')
 const domain = 'http://localhost:3000'
 
 // Dependencies
-const webshot = require('webshot')
+const webshot = require('webshot-node')
 const fs = require('fs')
 
 // Arguments


### PR DESCRIPTION
I always seem to get the following error when trying to generate screenshots with the provided script:

```
const { Math, Object } = primordials;
                         ^
ReferenceError: primordials is not defined
```

Using a forked version of the `webshot` package (which has a newer version of `graceful-fs` as a dependency) fixes this issue.