### PR TITLE
Make webshot-node work on Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@rollup/plugin-node-resolve": "^7.0.0",
     "accessible-autocomplete": "^2.0.1",
     "dotenv": "^8.2.0",
+    "fs-extra": "^9.0.0",
     "govuk-frontend": "^3.6.0",
     "lodash": "^4.17.15",
     "luxon": "^1.21.3",
@@ -60,7 +61,7 @@
     "npm-run-all": "^4.1.5",
     "rollup": "^2.2.0",
     "sharp": "^0.25.2",
-    "webshot": "^0.18.0"
+    "webshot-node": "^0.18.2"
   },
   "devDependencies": {
     "markdownlint-cli": "^0.22.0",

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -23,7 +23,7 @@ const domain = 'http://localhost:3000'
 
 // Dependencies
 const webshot = require('webshot-node')
-const fs = require('fs')
+const fs = require('fs-extra')
 
 // Arguments
 const directoryName = process.argv.slice(-1)[0]
@@ -57,11 +57,11 @@ function warnIfNoArguments (title) {
 
 function makeDirectories () {
   if (!fs.existsSync(imageDirectory)) {
-    fs.mkdirSync(imageDirectory)
+    fs.ensureDirSync(imageDirectory)
   }
 
   if (!fs.existsSync(postDirectory)) {
-    fs.mkdirSync(postDirectory)
+    fs.ensureDirSync(postDirectory)
   }
 }
 


### PR DESCRIPTION
So…
* `webshot` [fails with Node 12](https://github.com/DFE-Digital/bat-design-history/pull/59) 
* `webshot-node` works with Node 12

But…
* `webshot-node` and `fs` fail in Node 10.

Okay then. Lets try:
* `webshot-node`, and use `ensureDirSync()` function in `fs-extra`

😓