### PR TITLE
Trello-powered user needs (proof of concept)

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,6 +24,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter('fixed', require('./lib/filters/fixed'))
   eleventyConfig.addFilter('includes', require('./lib/filters/includes'))
   eleventyConfig.addFilter('markdown', require('./lib/filters/markdown'))
+  eleventyConfig.addFilter('needs', require('./lib/filters/needs'))
   eleventyConfig.addFilter('notifyPlaceholders', require('./lib/filters/notify-placeholders'))
   eleventyConfig.addFilter('pretty', require('./lib/filters/pretty'))
   eleventyConfig.addFilter('slug', require('./lib/filters/slug'))

--- a/app/_components/_all.scss
+++ b/app/_components/_all.scss
@@ -9,6 +9,7 @@
 @import "gallery/gallery";
 @import "header/header";
 @import "masthead/masthead";
+@import "need/need";
 @import "user-need/user-need";
 @import "pagination/pagination";
 @import "prose/prose";

--- a/app/_components/need/_need.scss
+++ b/app/_components/need/_need.scss
@@ -1,0 +1,40 @@
+.app-need {
+  display: flex;
+  flex-direction: column-reverse;
+  background-color: govuk-colour('light-grey');
+  padding: govuk-spacing(5);
+  margin-bottom: govuk-spacing(6);
+  position: relative;
+
+  &:hover {
+    background-color: darken(govuk-colour('light-grey'), 5%);
+  }
+
+  p:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.app-need__title {
+  @include govuk-font($size: 16);
+  margin: 0;
+  margin-top: govuk-spacing(2);
+
+  a::before {
+    content: "";
+    display: block;
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+  }
+}
+
+.app-need__tags {
+  position: absolute;
+  top: govuk-spacing(2);
+  right: govuk-spacing(2);
+  z-index: 0;
+}

--- a/app/_components/need/macro.njk
+++ b/app/_components/need/macro.njk
@@ -1,0 +1,3 @@
+{% macro appNeed(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/_components/need/template.njk
+++ b/app/_components/need/template.njk
@@ -1,0 +1,20 @@
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+
+<article class="app-need">
+  {%- if params.title -%}
+    <h3 class="app-need__title">
+      <a href="{{ params.url | url | pretty }}">{{ params.title }}</a>
+    </h3>
+  {%- endif -%}
+  <div class="app-need__tags">
+  {%- for label in params.labels -%}
+    {{- govukTag({
+      classes: "govuk-tag--" + (label.color | default("default")),
+      text: label.name | capitalize
+    }) -}}
+  {%- endfor -%}
+  </div>
+  <div class="app-need__description">
+    {{- params.description | markdown | safe -}}
+  </div>
+</article>

--- a/app/_components/needs/macro.njk
+++ b/app/_components/needs/macro.njk
@@ -1,0 +1,3 @@
+{% macro appNeeds(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/_components/needs/template.njk
+++ b/app/_components/needs/template.njk
@@ -1,0 +1,11 @@
+{% from "need/macro.njk" import appNeed %}
+
+{% for item in params.items %}
+  {% set item = item.data.need or item %}
+  {{ appNeed({
+    title: item.name,
+    description: item.desc,
+    labels: item.labels,
+    url: "/needs/" + item.shortLink
+  }) }}
+{% endfor %}

--- a/app/_data/needs.js
+++ b/app/_data/needs.js
@@ -1,0 +1,26 @@
+require('dotenv').config()
+
+const CacheAssets = require('@11ty/eleventy-cache-assets')
+
+module.exports = async function () {
+  const { TRELLO_KEY, TRELLO_TOKEN } = process.env
+  const trelloBoard = async (id) => {
+    const url = `https://api.trello.com/1/boards/${id}/cards?key=${TRELLO_KEY}&token=${TRELLO_TOKEN}`
+
+    try {
+      const data = await CacheAssets(url, {
+        duration: '1d',
+        type: 'json'
+      })
+
+      return data
+    } catch (error) {
+      console.warn(error.message)
+    }
+  }
+
+  return {
+    candidate: await trelloBoard('IN4oTADj'),
+    provider: await trelloBoard('5m1pMTme')
+  }
+}

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -53,6 +53,12 @@
           text: "Wiki",
           href: "https://dfedigital.atlassian.net/wiki/spaces/BaT/overview"
         }, {
+          text: "Candidate needs",
+          href: "/needs/candidate"
+        }, {
+          text: "Provider needs",
+          href: "/needs/provider"
+        }, {
           text: "Glossary",
           href: "/glossary"
         }]

--- a/app/_layouts/needs.njk
+++ b/app/_layouts/needs.njk
@@ -1,0 +1,32 @@
+{% extends "page.njk" %}
+
+{% from "pagination/macro.njk" import appPagination %}
+{% from "needs/macro.njk" import appNeeds %}
+
+{% set content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+      {% if pagination.items.length > 0 %}
+        {{ appNeeds({
+          items: pagination.items
+        }) }}
+      {% else %}
+        <p class="govuk-body">No needs found.</p>
+      {% endif %}
+
+      {{ appPagination({
+        previous: {
+          text: "Previous",
+          href: pagination.href.previous
+        } if pagination.href.previous,
+        next: {
+          text: 'Next',
+          href: pagination.href.next
+        } if pagination.href.next,
+        selected: pagination.pageNumber,
+        items: pagination.hrefs
+      }) }}
+    </div>
+  </div>
+{% endset %}

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -11,14 +11,14 @@
       tag: status
     },
     footer: {
-      date: page.date,
+      date: date or page.date,
       modified: modified if modified
     }
   }) %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       {{ appProse({
-        prose: content
+        prose: content | markdown | safe
       }) }}
     </div>
 

--- a/app/posts/apply-for-teacher-training/2020-06-24-international-candidates.md
+++ b/app/posts/apply-for-teacher-training/2020-06-24-international-candidates.md
@@ -13,6 +13,7 @@ tags:
 - AN026
 - AN027
 - MN015
+- o3kDbr6l
 ---
 
 When we launched the service in November, we de-scoped all features related to international recruitment.
@@ -66,8 +67,9 @@ It may be useful for international applicants to know which providers can sponso
 ### User need
 
 {% from "user-needs/macro.njk" import appUserNeeds %}
-{{ appUserNeeds({
-  items: collections['user-need'] | slugs(['AN025'])
+{% from "needs/macro.njk" import appNeeds %}
+{{ appNeeds({
+  items: collections["need"] | needs(["o3kDbr6l"])
 }) }}
 
 ### Hypothesis

--- a/app/posts/needs/candidate-need.njk
+++ b/app/posts/needs/candidate-need.njk
@@ -1,0 +1,27 @@
+---
+pagination:
+  data: needs.candidate
+  size: 1
+  alias: need
+  addAllPagesToCollections: true
+tags: need
+eleventyComputed:
+  permalink: "needs/{{ need.shortLink }}/"
+  title: "{{ need.name }}"
+  modified: "{{ need.dateLastActivity }}"
+  labels: "{{ need.labels }}"
+  eleventyNavigation:
+    key: "{{ title }}"
+    parent: Candidate needs
+---
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% for label in need.labels %}
+{{ govukTag({
+  text: label.name | capitalize,
+  classes: "govuk-tag--" + (label.color | default('default'))
+}) }}
+{% endfor %}
+
+{{ need.desc }}
+
+[View evidence for this need on Trello]({{ need.shortUrl }})

--- a/app/posts/needs/candidate-needs.njk
+++ b/app/posts/needs/candidate-needs.njk
@@ -1,0 +1,16 @@
+---
+tags: false
+layout: needs
+title: Candidate needs
+description: User needs for candidates applying for teacher training
+pagination:
+  data: needs.candidate
+  reverse: true
+  size: 50
+permalink: "needs/candidate/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% else %}index{% endif %}.html"
+eleventyComputed:
+  eleventyNavigation:
+    key: "{{ title }}"
+    excerpt: "{{ description }}"
+    parent: home
+---

--- a/app/posts/needs/needs.11tydata.js
+++ b/app/posts/needs/needs.11tydata.js
@@ -1,0 +1,19 @@
+module.exports = {
+  eleventyComputed: {
+    related: data => {
+      if (data.need) {
+        const relatedPosts = data.collections[data.need.shortLink]
+        if (relatedPosts) {
+          return {
+            title: 'Related posts',
+            items: relatedPosts.map(item => ({
+              text: item.data.title,
+              description: item.data.description,
+              href: item.url
+            }))
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/posts/needs/provider-need.njk
+++ b/app/posts/needs/provider-need.njk
@@ -1,0 +1,27 @@
+---
+pagination:
+  data: needs.provider
+  size: 1
+  alias: need
+  addAllPagesToCollections: true
+tags: need
+eleventyComputed:
+  permalink: "needs/{{ need.shortLink }}/"
+  title: "{{ need.name }}"
+  modified: "{{ need.dateLastActivity }}"
+  labels: "{{ need.labels }}"
+  eleventyNavigation:
+    key: "{{ title }}"
+    parent: Provider needs
+---
+{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% for label in need.labels %}
+{{ govukTag({
+  text: label.name | capitalize,
+  classes: "govuk-tag--" + (label.color | default('default'))
+}) }}
+{% endfor %}
+
+{{ need.desc }}
+
+[View evidence for this need on Trello]({{ need.shortUrl }})

--- a/app/posts/needs/provider-needs.njk
+++ b/app/posts/needs/provider-needs.njk
@@ -1,0 +1,16 @@
+---
+tags: false
+layout: needs
+title: Provider needs
+description: User needs for providers mangaging teacher training applications
+pagination:
+  data: needs.provider
+  reverse: true
+  size: 50
+permalink: "needs/provider/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% else %}index{% endif %}.html"
+eleventyComputed:
+  eleventyNavigation:
+    key: "{{ title }}"
+    excerpt: "{{ description }}"
+    parent: home
+---

--- a/lib/filters/date.js
+++ b/lib/filters/date.js
@@ -3,12 +3,15 @@ const { DateTime } = require('luxon')
 /**
  * Format a data using tokens
  *
- * @param {String} dateObject Date to convert
+ * @param {String} string Date to convert
  * @param {String} format Token-based formatting.
  * @example {{ date | date("OPTIONAL FORMAT STRING") }}
  *
  */
-module.exports = (dateObject, format) => {
+module.exports = (string, format) => {
+  // Enable special `now` value
+  const dateObject = (string === 'now') ? DateTime.local().toJSDate() : new Date(string)
+
   // Convert dateObj to Luxon DateTime object, using UTC
   // See: https://11ty.dev/docs/dates/#dates-off-by-one-day
   let date = DateTime.fromJSDate(dateObject, {

--- a/lib/filters/includes.js
+++ b/lib/filters/includes.js
@@ -1,23 +1,30 @@
-const get = require('lodash/get')
-
 /**
- * Find objects in array whose key includes a value
+/**
+ * Select objects in array whose key includes a value
  *
  * @param {Array} array Array to filter
- * @param {String} key Key to inspect
+ * @param {String} keyPath Key to inspect
  * @param {String} value Value key needs to include
  * @return {Array} Filtered array
  *
  */
-module.exports = (array, key, value) => {
+module.exports = (array, keyPath, value) => {
   return array.filter(item => {
-    const field = get(item, key)
+    let data = item
+    for (const key of keyPath.split('.')) {
+      data = data[key]
+    }
 
-    // If field doesn’t exist, abort
-    if (!field) {
+    // If data doesn’t exist, abort
+    if (!data) {
       return false
     }
 
-    return field.includes(value) ? item : false
+    // If data is a Date, reformat as ISO 8601
+    if (data instanceof Date) {
+      data = data.toISOString()
+    }
+
+    return (data.includes(value) ? item : false)
   })
 }

--- a/lib/filters/needs.js
+++ b/lib/filters/needs.js
@@ -1,0 +1,13 @@
+/**
+ * Find items in an array that match the slugs
+ *
+ * @param {Array} array Array to filter
+ * @param {Array} needs Array of need ids (strings)
+ * @return {Array} Filtered array
+ *
+ */
+module.exports = (array, needs) => {
+  return array.filter(item => {
+    return needs.includes(item.data.need.shortLink)
+  })
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "fs-extra": "^9.0.1",
     "govuk-frontend": "^3.10.2",
     "http-server": "^0.12.3",
-    "lodash": "^4.17.20",
     "luxon": "^1.25.0",
     "markdown-it-abbr": "^1.0.4",
     "markdown-it-anchor": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,13 @@
   },
   "dependencies": {
     "@11ty/eleventy": "^0.11.1",
+    "@11ty/eleventy-cache-assets": "^2.0.3",
     "@11ty/eleventy-navigation": "^0.1.6",
     "@11ty/eleventy-plugin-syntaxhighlight": "^3.0.4",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.1",
     "accessible-autocomplete": "^2.0.3",
+    "dotenv": "^8.2.0",
     "fs-extra": "^9.0.1",
     "govuk-frontend": "^3.10.2",
     "http-server": "^0.12.3",


### PR DESCRIPTION
Using Trello’s REST API, I wanted to see if was possible to use the user need boards to power the needs we are using on the design history site (thus, making it possible to manage needs in one place, not two).

This PR demonstrates that we can do this, while maintaining all the features we have currently (need embeds, posts related to a specific need, etc):

* [Candidate needs](https://deploy-preview-182--bat-design-history.netlify.app/needs/candidate)
* [Provider needs](https://deploy-preview-182--bat-design-history.netlify.app/needs/provider)
* [Candidate need page](https://deploy-preview-182--bat-design-history.netlify.app/needs/o3kDbr6l)
* [Post with user need embed](https://deploy-preview-182--bat-design-history.netlify.app/apply-for-teacher-training/international-candidates/#user-need)

If we think this is a good idea, next steps would be to:
* Decide if some cards should not be pulled through to the design history site (we can filter cards by tag if necessary)
* Review any needs that are on the design history site but not on the Trello boards, and consolidate them all there
* Review the Trello cards so that they display correctly/better on the design history site (there’s a bit of a mix, especially for provider needs)
* Update existing posts so they point to the Trello based need pages
* Remove the old needs implementation