### PR TITLE
Prevent heading anchors from being orphaned

### DIFF
--- a/app/_components/figure/template.njk
+++ b/app/_components/figure/template.njk
@@ -3,10 +3,7 @@
 <figure class="app-figure">
 {% if params.title %}
   <figcaption class="govuk-heading-s">
-    {{ params.title }}
-    {% if params.id %}
-      <a class="header-anchor" href="#{{ params.id }}">#</a>
-    {% endif %}
+    {{ params.title }}{% if params.id %}<a class="header-anchor" href="#{{ params.id }}">#</a>{% endif %}
   </figcaption>
 {% endif %}
 {% if params.embed %}

--- a/app/_components/prose/_prose.scss
+++ b/app/_components/prose/_prose.scss
@@ -179,6 +179,7 @@
     font-style: italic;
     font-weight: normal;
     color: govuk-colour("mid-grey");
+    margin-left: govuk-spacing(1);
 
     &:hover {
       color: $govuk-link-hover-colour;

--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -5,8 +5,7 @@
   {% if not params.hideContents %}
   <div class="govuk-!-display-none-print">
     <h{{ headingLevel }}>
-      {{ title }}
-      <a class="header-anchor" href="#{{ title | slug }}">#</a>
+      {{ title }}<a class="header-anchor" href="#{{ title | slug }}">#</a>
     </h{{ headingLevel }}>
     <ul class="govuk-list app-screenshots__contents">
       {% for item in params.items %}

--- a/lib/libraries/markdown.js
+++ b/lib/libraries/markdown.js
@@ -14,6 +14,7 @@ module.exports = (() => {
     .use(require('markdown-it-abbr'))
     .use(require('markdown-it-anchor'), {
       permalink: true,
+      permalinkSpace: false,
       permalinkSymbol: '#'
     })
     .use(require('markdown-it-deflist'))


### PR DESCRIPTION
Narrow viewport:
<img width="220" alt="Screenshot 2020-08-19 at 23 19 39" src="https://user-images.githubusercontent.com/813383/90695575-a32ce900-e272-11ea-8d94-636068ebc360.png">

Slightly less narrow viewport:
<img width="230" alt="Screenshot 2020-08-19 at 23 19 51" src="https://user-images.githubusercontent.com/813383/90695580-a45e1600-e272-11ea-973a-bf5675b68fbe.png">
