### PR TITLE
Placeholder for research round 1 entry added

### DIFF
--- a/app/posts/register-trainee-teachers/2020-10-06-beta-prototype-research-round-1.md
+++ b/app/posts/register-trainee-teachers/2020-10-06-beta-prototype-research-round-1.md
@@ -1,6 +1,6 @@
 ---
 title: Beta prototype research (Round 1)
-description: Validating existing Assessment Only user needs and testing the prototype
+description: Validating existing assessment only user needs and testing the prototype
 date: 2020-10-06
 related:
   items:

--- a/app/posts/register-trainee-teachers/2020-10-06-beta-prototype-research-round-1.md
+++ b/app/posts/register-trainee-teachers/2020-10-06-beta-prototype-research-round-1.md
@@ -1,0 +1,25 @@
+---
+title: Beta prototype research (Round 1)
+description: Validating existing Assessment Only user needs and testing the prototype
+date: 2020-10-06
+related:
+  items:
+  - text: Research playback
+    href: https://docs.google.com/presentation/d/1_iH4sW9sHr-ICvm8pwA5UaJFToWsQjf-P8U2A3fbYXw/
+  - text: Research recordings
+    href: https://drive.google.com/drive/folders/1QCEACDDATmeRmehgHy4CBJi3CGLgEW66
+---
+
+Our intention in this first round of research was to answer the following questions:
+
+* Can users navigate through the service successfully?
+* Are we meeting the user needs for the Assessment Only route?
+* Are we requesting the right data, relevant to the Assessment Only route?
+
+## Who we tested with
+
+* University of Winchester
+* University of East London
+* University of Southampton
+* Essex & Thames SCITT
+* Surrey South Farnham SCITT

--- a/app/posts/register-trainee-teachers/2020-10-06-beta-prototype-research-round-1.md
+++ b/app/posts/register-trainee-teachers/2020-10-06-beta-prototype-research-round-1.md
@@ -1,5 +1,5 @@
 ---
-title: Beta prototype research (Round 1)
+title: Beta prototype research (round 1)
 description: Validating existing assessment only user needs and testing the prototype
 date: 2020-10-06
 related:


### PR DESCRIPTION
I'm adding a placeholder entry for the first round of research so we all have access to the playback deck and I have an entry to reference in the follow up entry about iterating the prototype.

Ana is working on adding more content to this entry.