### PR TITLE
Notify placeholder syntax styling for email previews 

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,6 +24,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter('fixed', require('./lib/filters/fixed'))
   eleventyConfig.addFilter('includes', require('./lib/filters/includes'))
   eleventyConfig.addFilter('markdown', require('./lib/filters/markdown'))
+  eleventyConfig.addFilter('notifyPlaceholders', require('./lib/filters/notify-placeholders'))
   eleventyConfig.addFilter('pretty', require('./lib/filters/pretty'))
   eleventyConfig.addFilter('slug', require('./lib/filters/slug'))
   eleventyConfig.addFilter('slugs', require('./lib/filters/slugs'))
@@ -60,7 +61,7 @@ module.exports = function (eleventyConfig) {
       return !item.data.tags.includes('user-need');
     });
   });
-  
+
   eleventyConfig.addCollection('register-trainee-teachers', function(collection) {
     return collection.getFilteredByTag('register-trainee-teachers').filter(function(item) {
       return !item.data.tags.includes('user-need');

--- a/app/_components/email/template.njk
+++ b/app/_components/email/template.njk
@@ -3,9 +3,9 @@
   <dl class="app-email__headers">
     <div class="app-email__headers__row">
       <dt class="app-email__headers__key">Subject</dt>
-      <dd class="app-email__headers__value">{{- params.subject | safe if params.subject -}}</dd>
+      <dd class="app-email__headers__value">{{- params.subject | notifyPlaceholders | safe if params.subject -}}</dd>
     </div>
   </dl>
 {%- endif %}
-{{- params.content | markdown | safe if params.content -}}
+{{- params.content | notifyPlaceholders | markdown | safe if params.content -}}
 </div>

--- a/app/posts/apply-for-teacher-training/2020-03-09-course-full-after-submitting.md
+++ b/app/posts/apply-for-teacher-training/2020-03-09-course-full-after-submitting.md
@@ -69,15 +69,15 @@ We also don’t know how important the course is to a candidate – if it's thei
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
   subject: "A course you’ve applied to is full",
-  content: "You applied to the course [provider] – [course] ([code]). The provider marked this course as full before we received your references.
+  content: "You applied to the course ((provider_name)) – ((course_name)) (((course_code))). The provider marked this course as full before we received your references.
 
 If you do nothing your application will be sent. Some providers will still consider your application because it was submitted before they marked the course as full.
 
-You still have [X days] to edit your application. You can:
+You still have ((days_remaining)) to edit your application. You can:
 
-* add another course [ if less than 3 courses ]
-* change this course to another one [ if 3 courses ]
+* ((if less than 3 courses??add another course))
+* ((if 3 courses??change this course to another one))
 * do nothing and we will still send your application to your training provider
 
-[link to application]"
+((link_to_application))"
 }) }}

--- a/app/posts/apply-for-teacher-training/2020-03-24-coronavirus.md
+++ b/app/posts/apply-for-teacher-training/2020-03-24-coronavirus.md
@@ -20,7 +20,7 @@ We communicated this information to candidates by:
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
   subject: "There might be a delay in processing your teacher training application",
-  content: "Dear [candidateName]
+  content: "Dear ((candidate_name))
 
   Given the impact of coronavirus (COVID-19) on schools and universities, your teacher training application might be processed more slowly than usual.
 

--- a/app/posts/apply-for-teacher-training/2020-05-18-making-the-references-process-faster.md
+++ b/app/posts/apply-for-teacher-training/2020-05-18-making-the-references-process-faster.md
@@ -90,11 +90,11 @@ Because users will:
 
 > ### You need to add a new referee
 
-> [Referee] has not responded.
+> ((referee_name)) has not responded.
 
 > Add a new referee as soon as possible. Courses can become full at any time and providers do not consider applications without 2 references.
 
-> Adding a new referee will not prevent [Referee] from giving a reference. You can keep chasing [Referee] if you know they’re planning on giving a reference.
+> Adding a new referee will not prevent ((referee_name)) from giving a reference. You can keep chasing ((referee_name)) if you know they’re planning on giving a reference.
 
 > [Add new referee]
 
@@ -109,7 +109,7 @@ Because users will:
 
 > ### You need to add a new referee
 
-> You cancelled your request for a reference from [Referee].
+> You cancelled your request for a reference from ((referee_name)).
 
 > Add a new referee as soon as possible. Courses can become full at any time and providers do not consider applications without 2 references.
 
@@ -140,23 +140,23 @@ To avoid complexity and outdated content, we give instructions on the states whi
 {{ appEmail({
   content: "
 
-> Dear [Referee]
+> Dear ((referee_name))
 
-> ### Give a reference for [Candidate] as soon as possible
+> ### Give a reference for ((candidate_name)) as soon as possible
 
-> [Candidate] put us in touch with you to get a reference for their teacher training application. They applied to:
+> ((candidate_name)) put us in touch with you to get a reference for their teacher training application. They applied to:
 
-> [list courses]
+> ((course_choices))
 
 > Give a reference as soon as possible by filling in this short form (it does not take long):
 
-> [link]
+> ((link))
 
 > Teacher training courses can become full at any time. The sooner [Candidate] gets a reference, the more likely it is that they’ll get a place.
 
 > Let us know as soon as possible if you will not give a reference:
 
-> [link]
+> ((link))
 
 > ### Your data
 
@@ -173,11 +173,11 @@ To avoid complexity and outdated content, we give instructions on the states whi
 {{ appEmail({
   content: "
 
-> Dear [Candidate]
+> Dear ((candidate_name))
 
 > ### Get in contact with your referee as soon as possible
 
-> [Referee] has not given you a reference yet.
+> ((referee_name)) has not given you a reference yet.
 
 > Ask them to check their inbox including their junk or spam emails and give a reference as soon as possible.
 
@@ -185,11 +185,11 @@ To avoid complexity and outdated content, we give instructions on the states whi
 
 > You gave us this email address:
 
-> [address]
+> ((referee_email_address))
 
 > If this is not correct, cancel the reference request and add in the referee details again:
 
-> [link]
+> ((link))
 
 > We cannot send your application to your teacher training providers without 2 references. Courses can become full at any time - get your reference as soon as possible.
 

--- a/app/posts/apply-for-teacher-training/2020-10-06-end-of-cycle-and-carry-over.md
+++ b/app/posts/apply-for-teacher-training/2020-10-06-end-of-cycle-and-carry-over.md
@@ -111,7 +111,7 @@ On the 18 September, candidates get an email:
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
   subject: "Your references did not come back in time",
-  content: "Dear <span class=\"placeholder\">((candidate))</span>
+  content: "Dear ((candidate))
 
 #### Your references did not come back in time
 
@@ -119,7 +119,7 @@ Your referees did not respond in time for courses starting in the 2020 to 2021 a
 
 You can update your referees and apply again for courses starting in the 2021 to 2022 academic year.
 
-<span class=\"placeholder\">((dashboard_url))</span>
+((dashboard_url))
 
 #### Get support
 
@@ -176,23 +176,23 @@ When a teacher training provider rejects an application, the candidate gets an e
 
 {{ appEmail({
   subject: "Your application was unsuccessful but you can apply again",
-  content: "Dear <span class=\"placeholder\">((candidate))</span>
+  content: "Dear ((candidate))
 
 #### Application decision
 
-<span class=\"placeholder-conditional\">((rejected_automatically??</span><span class=\"placeholder\">((provider))</span> did not respond to your application for <span class=\"placeholder\">((course_and_code))</span> in time.))
+((rejected_automatically??((provider)) did not respond to your application for ((course_and_code)) in time.))
 
-<span class=\"placeholder-conditional\">((rejected_by_provider??</span><span class=\"placeholder\">((provider))</span> decided not to progress your teacher training application for <span class=\"placeholder\">((course_and_code))</span> on this occasion.))
+((rejected_by_provider??((provider)) decided not to progress your teacher training application for ((course_and_code)) on this occasion.))
 
 #### You can apply again
 
 It’s easy to apply again. We’ve saved your last application, so all you have to do is make any changes and submit.
 
-<span class=\"placeholder-conditional\">((has_feedback??</span>Review your feedback and apply again:))
+((has_feedback??Review your feedback and apply again:))
 
-<span class=\"placeholder-conditional\">((no_feedback??</span>Apply again:))
+((no_feedback??Apply again:))
 
-<span class=\"placeholder\">((dashboard_url))</span>
+((dashboard_url))
 
 #### Get support
 
@@ -249,7 +249,7 @@ Before 18 September, candidates get an email:
 
 {{ appEmail({
   subject: "Submit your application no later than 18 September",
-  content: "Dear <span class=\"placeholder\">((candidate))</span>
+  content: "Dear ((candidate))
 
 #### Submit your application no later than 18 September
 
@@ -257,7 +257,7 @@ If you’re hoping to start a course this academic year, submit your application
 
 Review and submit your application:
 
-<span class=\"placeholder\">((sign_in_url))</span>
+((sign_in_url))
 
 #### Ask your provider how quickly you need to submit: courses are filling up
 
@@ -265,7 +265,7 @@ Although 18 September is the last day you can submit your application, courses c
 
 Contact your teacher training provider to check availability.
 
-<span class=\"placeholder\">((provider_contact_details))</span>
+((provider_contact_details))
 
 #### Get support
 

--- a/app/posts/apply-for-teacher-training/2020-10-09-getting-references-before-submitting.md
+++ b/app/posts/apply-for-teacher-training/2020-10-09-getting-references-before-submitting.md
@@ -224,8 +224,8 @@ We’ll know these changes work if:
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "<span class=\"placeholder\">((referee_name))</span> has not responded yet",
-  content: "#### <span class=\"placeholder\">((referee_name))</span> has not responded yet
+  subject: "((referee_name)) has not responded yet",
+  content: "#### ((referee_name)) has not responded yet
 
   You can add as many referees as you like to increase the chances of getting 2 references quickly.
 
@@ -233,7 +233,7 @@ We’ll know these changes work if:
 
   Manage your references:
 
-  <span class=\"placeholder\">((manage_references_url))</span>
+  ((manage_references_url))
 
   You cannot submit your application without 2 references. Courses can become full anytime - get your references as soon as possible."
 }) }}
@@ -241,8 +241,8 @@ We’ll know these changes work if:
 ### Reference request failed
 
 {{ appEmail({
-  subject: "Referee request did not reach <span class=\"placeholder\">((referee_name))</span>",
-  content: "#### Referee request did not reach <span class=\"placeholder\">((referee_name))</span>
+  subject: "Referee request did not reach ((referee_name))",
+  content: "#### Referee request did not reach ((referee_name))
 
   Check you gave the correct email address and request the reference again.
 
@@ -252,7 +252,7 @@ We’ll know these changes work if:
 
   Manage your references:
 
-  <span class=\"placeholder\">((manage_references_url))</span>
+  ((manage_references_url))
 
   You cannot submit your application without 2 references. Courses can become full anytime – get your references as soon as possible."
 }) }}
@@ -260,8 +260,8 @@ We’ll know these changes work if:
 ### Reference declined
 
 {{ appEmail({
-  subject: "<span class=\"placeholder\">((referee_name))</span> has declined your reference request",
-  content: "#### <span class=\"placeholder\">((referee_name))</span> has declined your reference request
+  subject: "((referee_name)) has declined your reference request",
+  content: "#### ((referee_name)) has declined your reference request
 
   You can add as many referees as you like to increase the chances of getting 2 references quickly.
 
@@ -269,7 +269,7 @@ We’ll know these changes work if:
 
   Manage your references:
 
-  <span class=\"placeholder\">((manage_references_url))</span>
+  ((manage_references_url))
 
   You cannot submit your application without 2 references. Courses can become full anytime – get your references as soon as possible."
 }) }}
@@ -277,8 +277,8 @@ We’ll know these changes work if:
 ### Reference given
 
 {{ appEmail({
-  subject: "You have a reference from <span class=\"placeholder\">((referee_name))</span>",
-  content: "#### You have a reference from <span class=\"placeholder\">((referee_name))</span>
+  subject: "You have a reference from ((referee_name))",
+  content: "#### You have a reference from ((referee_name))
 
   You need to get another reference back before you can send your application to training providers.
 
@@ -286,14 +286,14 @@ We’ll know these changes work if:
 
   Manage your references:
 
-  <span class=\"placeholder\">((manage_references_url))</span>"
+  ((manage_references_url))"
 }) }}
 
 ### Second references given
 
 {{ appEmail({
-  subject: "You have a reference from <span class=\"placeholder\">((referee_name))</span>",
-  content: "#### You have a reference from <span class=\"placeholder\">((referee_name))</span>
+  subject: "You have a reference from ((referee_name))",
+  content: "#### You have a reference from ((referee_name))
 
   You’ve got 2 references back now.
 
@@ -301,5 +301,5 @@ We’ll know these changes work if:
 
   Sign in to continue your application:
 
-  <span class=\"placeholder\">((dashboard_url))</span>"
+  ((dashboard_url))"
 }) }}

--- a/app/posts/apply-for-teacher-training/ucas/emails.md
+++ b/app/posts/apply-for-teacher-training/ucas/emails.md
@@ -9,20 +9,20 @@ With an application started in March 2019, the following emails were sent over t
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "[First name], here’s what you need to do now",
+  subject: "((first_name)), here’s what you need to do now",
   content: "![Now you’ve started your UCAS Teacher Training application, you’re one step closer to becoming a teacher.](/images/apply-for-teacher-training/ucas/emails/day1.png)"
 }) }}
 
 ## 1 week after starting an application
 
 {{ appEmail({
-  subject: "[First name], make your application stand out",
+  subject: "((first_name)), make your application stand out",
   content: "![It’s been just over a week since you started your UCAS Teacher Training application…](/images/apply-for-teacher-training/ucas/emails/day7.png)"
 }) }}
 
 ## 3 weeks after starting an application
 
 {{ appEmail({
-  subject: "[First name], it’s time to apply",
+  subject: "((first_name)), it’s time to apply",
   content: "![We’ve got loads of support to help you with your application](/images/apply-for-teacher-training/ucas/emails/day21.png)"
 }) }}

--- a/app/posts/manage-teacher-training-applications/2020-03-24-coronavirus.md
+++ b/app/posts/manage-teacher-training-applications/2020-03-24-coronavirus.md
@@ -21,7 +21,7 @@ We communicated this change to providers by:
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
   subject: "Coronavirus: how Apply for teacher training is adapting",
-  content: "Dear [providerName]
+  content: "Dear ((provider_name))
 
   You may have heard from UCAS that we won’t be rejecting or declining any offers automatically until 20 April 2020.
 

--- a/app/posts/manage-teacher-training-applications/2020-11-27-reasons-for-rejection-iteration-4.md
+++ b/app/posts/manage-teacher-training-applications/2020-11-27-reasons-for-rejection-iteration-4.md
@@ -4,6 +4,8 @@ description: Various improvements to reasons for rejection
 date: 2020-11-27
 ---
 
+<!-- markdownlint-disable MD024 MD025 -->
+
 {% from "email/macro.njk" import appEmail %}
 
 This iteration contains the following improvements:
@@ -24,12 +26,11 @@ This iteration contains the following improvements:
   subject: "Update on your application - all decisions now made",
   content: "
 
-Dear {name}
+Dear ((name))
 
-<!-- markdownlint-disable MD024 MD025 -->
 # Update on your application
 
-{Provider} has decided not to make you an offer to study {course}. They've given feedback to explain this decision.
+((provider)) has decided not to make you an offer to study ((course)). They've given feedback to explain this decision.
 
 > **Quality of application**
 >
@@ -45,20 +46,16 @@ Dear {name}
 >
 > The provider would not be interested in future applications from you.
 
-Contact {provider} directly if you have any questions about their feedback.
+Contact ((provider)) directly if you have any questions about their feedback.
 
-<!-- markdownlint-disable MD024 MD025 -->
 # You can apply again
 
-{if this was not the only application}
-  You’ve now had decisions about all the courses you applied for. You did not get any offers, so you can apply again.
-{endif}
+((if this was not the only application??You’ve now had decisions about all the courses you applied for. You did not get any offers, so you can apply again.))
 
 Your last application has been saved. You can make changes before you submit your new application.
 
-{link}
+((link))
 
-<!-- markdownlint-disable MD024 MD025 -->
 # Get support
 
 If you need help getting a place on a course, contact Get Into Teaching (8:30am to 5pm Monday to Friday). Call for free on 0800 389 2500 or chat to an adviser online:
@@ -75,12 +72,11 @@ Contact becomingateacher@digital.education.gov.uk if you have problems applying 
   subject: "Update on your application - decide what to do",
   content: "
 
-Dear {name}
+Dear ((name))
 
-<!-- markdownlint-disable MD024 MD025 -->
 # Update on your application
 
-{Provider} has decided not to make you an offer to study {course}. They've given feedback to explain this decision.
+((provider)) has decided not to make you an offer to study ((course)). They've given feedback to explain this decision.
 
 > **Quality of application**
 >
@@ -96,19 +92,17 @@ Dear {name}
 >
 > The provider would not be interested in future applications from you.
 
-Contact {provider} directly if you have any questions about their feedback.
+Contact ((provider)) directly if you have any questions about their feedback.
 
-<!-- markdownlint-disable MD024 MD025 -->
 # You have an offer and are waiting for a decision about another course
 
-You have an offer from {provider1} to study {course1}.
+You have an offer from ((provider1)) to study ((course1)).
 
-{provider2} has until {date} to make a decision about your application to study {course2}.
+((provider2)) has until ((date)) to make a decision about your application to study ((course2)).
 
 You can wait until you’ve received both decisions before you respond. Alternatively you can sign in to you account and accept the offer you’ve already got:
 
-{link}
-
+((link))
 
 # Get support
 
@@ -123,12 +117,11 @@ Contact becomingateacher@digital.education.gov.uk if you have problems applying 
   subject: "Update on your application",
   content: "
 
-Dear {name}
+Dear ((name))
 
-<!-- markdownlint-disable MD024 MD025 -->
 # Update on your application
 
-{Provider} has decided not to make you an offer to study {course}. They've given feedback to explain this decision.
+((provider)) has decided not to make you an offer to study ((course)). They've given feedback to explain this decision.
 
 > **Quality of application**
 >
@@ -144,25 +137,24 @@ Dear {name}
 >
 > The provider would not be interested in future applications from you.
 
-Contact {provider} directly if you have any questions about their feedback.
+Contact ((provider)) directly if you have any questions about their feedback.
 
-{ if one }
-<!-- markdownlint-disable MD024 MD025 -->
+((if one??
+
 # You’re waiting for a decision
 
-You’re waiting for {provider} to make a decision about your application to study {course}. They should do this by {date}.
+You’re waiting for ((provider)) to make a decision about your application to study ((course)). They should do this by ((date)).
 
-{ else }
+((else??
 <!-- markdownlint-disable MD024 MD025 -->
 # You’re waiting for decisions
 
 You’re waiting for decisions about your applications to:
 
-- {provider} to study {course}
-- {provider} to study {course}
+- ((provider)) to study ((course))
+- ((provider)) to study ((course))
 
-They should make their decisions by {date}.
-{ endif }
+They should make their decisions by ((date)).
 
 ## Get support
 

--- a/app/posts/publish-teacher-training-courses/2020-01-23-notifications-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2020-01-23-notifications-mvp.md
@@ -1,13 +1,13 @@
 ---
 title: Notifications MVP
-description: Identifying an initial set of notifications and the critical user flows required to manage notifications in Publish.  
+description: Identifying an initial set of notifications and the critical user flows required to manage notifications in Publish.
 date: 2020-01-23
 tags:
  - PN003
 ---
 UCAS provided email notifications to it's users. This functionality is yet be introduced to Publish teacher training courses. To address this, we established an introductory set of notifications to satisfy our user’s critical needs.
 
-We learned through the [accredited bodies research](https://bat-design-history.netlify.com/publish-teacher-training-courses/accredited-bodies-research-round-2#a-need-for-notifications) that there was a need for notifications to be sent to accredited bodies about changes made in Publish. 
+We learned through the [accredited bodies research](https://bat-design-history.netlify.com/publish-teacher-training-courses/accredited-bodies-research-round-2#a-need-for-notifications) that there was a need for notifications to be sent to accredited bodies about changes made in Publish.
 
 ## User needs
 
@@ -44,7 +44,7 @@ Dear colleague,
 
 A change has been made in Find postgraduate teacher training to a course that you’re listed as the accredited body for.
 
-((provider_name)) changed the ((attribute_changed)) of ((course_name)) (((course_code))) from “((original_value))” to “((updated_value))“. The change was made at ((attribute_change_datetime)).
+((provider_name)) changed the ((attribute_changed)) of ((course_name)) (((course_code))) from “((original_value))” to “((updated_value))”. The change was made at ((attribute_change_datetime)).
 
 View the course at ((course_url)).
 
@@ -59,7 +59,7 @@ The Becoming a Teacher team
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "Course [course_name] (course_code) has been updated",
+  subject: "Course ((course_name)) (((course_code))) has been updated",
   content: template1
 }) }}
 
@@ -86,7 +86,7 @@ The Becoming a Teacher team
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "Course [course_name] (course_code) has been published",
+  subject: "Course ((course_name)) (((course_code))) has been published",
   content: template2
 }) }}
 
@@ -97,11 +97,11 @@ Dear colleague,
 
 A new course has been created in Publish teacher training courses, and your organisation has been added as the accredited body for it.
 
-((Provider_name)) created ((course_name)) ((course_code)) at ((create_course_datetime)). The course has not yet been published on Find postgraduate teacher training. You’ll receive a notification if it is published.
+((provider_name)) created ((course_name)) (((course_code))) at ((create_course_datetime)). The course has not yet been published on Find postgraduate teacher training. You’ll receive a notification if it is published.
 
 View the course at ((publish_url)).
 
-If you have any questions about this, please notify your contact at ((provider_name)). 
+If you have any questions about this, please notify your contact at ((provider_name)).
 
 To stop receiving these notifications, or to update your settings, go to https://www.publish-teacher-training-courses.service.gov.uk/notifications.
 
@@ -111,7 +111,7 @@ The Becoming a Teacher team
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "Course [course_name] (course_code) has been created",
+  subject: "Course ((course_name)) (((course_code))) has been created",
   content: template6
 }) }}
 
@@ -122,13 +122,13 @@ Dear colleague,
 
 A course, which your organisation is the accredited body for, has been withdrawn from Find postgraduate teacher training.
 
-((provider_name)) withdrew ((course name)) (((course code))) in Publish teacher training courses, at ((attribute_change_datetime)).
+((provider_name)) withdrew ((course name)) (((course_code))) in Publish teacher training courses, at ((attribute_change_datetime)).
 
 This course is no longer visible on Find and candidates can’t apply to it. It also can’t be republished or reopened to applicants in the current cycle.
 
 You can view the withdrawn course in Publish at ((course url)).
 
-If you have any questions about this change, please notify your contact at ((provider_name)). 
+If you have any questions about this change, please notify your contact at ((provider_name)).
 
 To stop receiving these notifications, or to update your settings, go to https://www.publish-teacher-training-courses.service.gov.uk/notifications.
 
@@ -138,7 +138,7 @@ The Becoming a Teacher team
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "Course [course_name] (course_code) has been withdrawn",
+  subject: "Course ((course_name)) (((course_code))) has been withdrawn",
   content: template3
 }) }}
 
@@ -153,7 +153,7 @@ The accredited body for ((course_name)) (((course_code))) was previously ((old a
 
 View the course at ((course_url)).
 
-If you have any questions about this, please notify your contact at ((provider_name)).  
+If you have any questions about this, please notify your contact at ((provider_name)).
 
 To stop receiving these notifications, or to update your settings, go to https://www.publish-teacher-training-courses.service.gov.uk/notifications.
 
@@ -163,7 +163,7 @@ The Becoming a Teacher team
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "You are now listed as the accredited body for [course_name] (course_code)",
+  subject: "You are now listed as the accredited body for ((course_name)) (((course_code)))",
   content: template4
 }) }}
 
@@ -188,7 +188,7 @@ The Becoming a Teacher team
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  subject: "Course [course_name] (course_code) has a new accredited body",
+  subject: "Course ((course_name)) (((course_code))) has a new accredited body",
   content: template5
 }) }}
 
@@ -198,4 +198,4 @@ Next steps will include:
 
 * A notifications pilot with a small number of providers who have expressed a key interest in receiving notifications.
 * A diary study conducted with the pilot participants.
-* Design and research of "manage notifications" functionality for Publish.     
+* Design and research of "manage notifications" functionality for Publish.

--- a/app/posts/publish-teacher-training-courses/2020-06-15-request-pe-courses.md
+++ b/app/posts/publish-teacher-training-courses/2020-06-15-request-pe-courses.md
@@ -27,7 +27,6 @@ The allocations team will be in contact with these organisations individually.
 This email was sent to accredited bodies on 8 June 2020.
 
 {% set requestPeEmail %}
-
 Dear Colleague
 
 In April, we contacted you about requesting teacher training courses for the 2021/22 recruitment cycle.

--- a/lib/filters/notify-placeholders.js
+++ b/lib/filters/notify-placeholders.js
@@ -1,0 +1,13 @@
+/**
+ * Use GOV.UK Notify-style placeholders in email examples
+ *
+ * @param {String} string Original text
+ * @return {String} HTML
+ *
+ */
+module.exports = string => {
+  let html = string.replace(/\(\(([\w\s]+)\?\?/g, '<span class="placeholder-conditional">(($1??</span>')
+  html = html.replace(/\(\(([\w\s]+)\)\)/g, '<span class="placeholder">(($1))</span>')
+
+  return html
+}


### PR DESCRIPTION
Allows you to use Notify email syntax for placeholders and conditionals:

`((this is a placeholder))`

`((this is a conditional??thing that only shows if true))`

I experimented with using this on an earlier post, but ended up adding HTML manually. This PR adds a Nunjucks filter to automate this process, and makes this formatting available to the email preview component, `appEmail`. I have also updated previous email templates to use this syntax too.

## Example

The following text:

```
It’s easy to apply again. We’ve saved your last application, so all you
have to do is make any changes and submit.

((has_feedback??Review your feedback and apply again:))

((no_feedback??Apply again:))

((dashboard_url))
```

Appears highlighted as follows:

<img width="579" alt="Screenshot 2020-12-01 at 01 12 22" src="https://user-images.githubusercontent.com/813383/100684482-53ca7e80-3372-11eb-9bfd-4962b35dd2b0.png">
