### PR TITLE
Review Markdown linting

### DIFF
--- a/.markdownlintrc
+++ b/.markdownlintrc
@@ -5,9 +5,7 @@
   "first-line-h1": false,
   "first-heading-h1": false,
   "no-bare-urls": false,
-  "no-duplicate-heading": {
-    "siblings_only": true
-  },
+  "no-duplicate-heading": false,
   "no-inline-html": false,
   "no-trailing-punctuation": {
     "punctuation": ".,;:"

--- a/app/posts/apply-for-teacher-training/2020-05-18-making-the-references-process-faster.md
+++ b/app/posts/apply-for-teacher-training/2020-05-18-making-the-references-process-faster.md
@@ -5,7 +5,6 @@ date: 2020-05-18
 tags:
 - AN024
 ---
-<!-- markdownlint-disable MD024 -->
 
 On average it takes about 11 days to get references.
 

--- a/app/posts/find-teacher-training/2018-07-20-all-courses-minimum.md
+++ b/app/posts/find-teacher-training/2018-07-20-all-courses-minimum.md
@@ -34,7 +34,6 @@ Aiming to test:
 
 We [iterated this design](/find-teacher-training/mvp-iteration-jul-25) during research.
 
-<!-- markdownlint-disable MD024 -->
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
   items: [{

--- a/app/posts/find-teacher-training/private-beta/2018-04-25-user-research-apr-25.md
+++ b/app/posts/find-teacher-training/private-beta/2018-04-25-user-research-apr-25.md
@@ -8,7 +8,6 @@ Testing with users in the [middle of the digital inclusion scale](https://www.go
 * [Research summary](https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/301596673/15th+Round+-+26th+April)
 * [Discussion guide](https://docs.google.com/document/d/12-FAWM0O5FxnodMo2B_1t4y88iOWSPqTZALVfhNC1Tc/edit)
 
-<!-- markdownlint-disable MD024 -->
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
   items: [{

--- a/app/posts/find-teacher-training/private-beta/2018-05-10-user-research-may-10.md
+++ b/app/posts/find-teacher-training/private-beta/2018-05-10-user-research-may-10.md
@@ -5,7 +5,6 @@ date: 2018-05-10
 tags: find-private-beta
 ---
 
-<!-- markdownlint-disable MD024 -->
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
   items: [{

--- a/app/posts/manage-teacher-training-applications/2020-11-27-reasons-for-rejection-iteration-4.md
+++ b/app/posts/manage-teacher-training-applications/2020-11-27-reasons-for-rejection-iteration-4.md
@@ -4,28 +4,25 @@ description: Various improvements to reasons for rejection
 date: 2020-11-27
 ---
 
-<!-- markdownlint-disable MD024 MD025 -->
+<!-- markdownlint-disable MD001 MD025 -->
 
 {% from "email/macro.njk" import appEmail %}
 
 This iteration contains the following improvements:
 
-- Removed negative contractions
-- Removed ‘Advice’ and ‘Details’ prefixes on candidate feedback
-- Changed to heading level 2 for candidate feedback on check answers page
-- Removed introductory content from within the candidate feedback (inset text)
-- Removed pleasantries like ‘Sorry’ and ‘Please’
-- Removed capitalisation on maths and science
-- Improved general clarity of the questions
+* Removed negative contractions
+* Removed ‘Advice’ and ‘Details’ prefixes on candidate feedback
+* Changed to heading level 2 for candidate feedback on check answers page
+* Removed introductory content from within the candidate feedback (inset text)
+* Removed pleasantries like ‘Sorry’ and ‘Please’
+* Removed capitalisation on maths and science
+* Improved general clarity of the questions
 
 ## Emails
 
 ### When all applications have been rejected
 
-{{ appEmail({
-  subject: "Update on your application - all decisions now made",
-  content: "
-
+{% set template1 %}
 Dear ((name))
 
 # Update on your application
@@ -63,15 +60,16 @@ If you need help getting a place on a course, contact Get Into Teaching (8:30am 
 https://getintoteaching.education.gov.uk/lp/live-chat
 
 Contact becomingateacher@digital.education.gov.uk if you have problems applying online or want to give feedback.
-  "
+{% endset %}
+
+{{ appEmail({
+  subject: "Update on your application - all decisions now made",
+  content: template1
 }) }}
 
 ## When waiting for one decision and has one offer
 
-{{ appEmail({
-  subject: "Update on your application - decide what to do",
-  content: "
-
+{% set template2 %}
 Dear ((name))
 
 # Update on your application
@@ -107,16 +105,16 @@ You can wait until you’ve received both decisions before you respond. Alternat
 # Get support
 
 Contact becomingateacher@digital.education.gov.uk if you have problems applying online or want to give feedback.
-  "
-}) }}
-
-<!-- markdownlint-disable MD001  -->
-### When waiting for one or two decisions and no offers made
+{% endset %}
 
 {{ appEmail({
-  subject: "Update on your application",
-  content: "
+  subject: "Update on your application - decide what to do",
+  content: template2
+}) }}
 
+### When waiting for one or two decisions and no offers made
+
+{% set template3 %}
 Dear ((name))
 
 # Update on your application
@@ -146,20 +144,24 @@ Contact ((provider)) directly if you have any questions about their feedback.
 You’re waiting for ((provider)) to make a decision about your application to study ((course)). They should do this by ((date)).
 
 ((else??
-<!-- markdownlint-disable MD024 MD025 -->
+
 # You’re waiting for decisions
 
 You’re waiting for decisions about your applications to:
 
-- ((provider)) to study ((course))
-- ((provider)) to study ((course))
+* ((provider)) to study ((course))
+* ((provider)) to study ((course))
 
 They should make their decisions by ((date)).
 
 ## Get support
 
 Contact becomingateacher@digital.education.gov.uk if you have problems applying online or want to give feedback.
-  "
+{% endset %}
+
+{{ appEmail({
+  subject: "Update on your application",
+  content: template3
 }) }}
 
 ## Potential improvements

--- a/app/posts/publish-teacher-training-courses/2018-07-05-templates.md
+++ b/app/posts/publish-teacher-training-courses/2018-07-05-templates.md
@@ -82,7 +82,6 @@ There’s some concept of a template in the tool provided by UCAS. Users can sel
 
 [UCAS documentation for ‘Entry profiles’](https://www.ucas.com/file/115116/download?token=Du-edwFy)
 
-<!-- markdownlint-disable MD024 -->
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
   items: [{


### PR DESCRIPTION
* Disable `MD024 - Multiple headings with the same content`
* Move email content into variable blocks, so markdown-lint only needs to run once on a page, not again within `appEmail` component content