### PR TITLE
WIP: Replace GOV.UK branding

### DIFF
--- a/app/_components/_all.scss
+++ b/app/_components/_all.scss
@@ -6,6 +6,7 @@
 @import "email/email";
 @import "embed/embed";
 @import "figure/figure";
+@import "footer/footer";
 @import "gallery/gallery";
 @import "header/header";
 @import "masthead/masthead";

--- a/app/_components/breadcrumbs/_breadcrumbs.scss
+++ b/app/_components/breadcrumbs/_breadcrumbs.scss
@@ -1,5 +1,5 @@
 $app-breadcrumbs-inverted-text-colour: govuk-colour("white");
-$app-breadcrumbs-inverted-border-colour: govuk-colour("light-blue");
+$app-breadcrumbs-inverted-border-colour: $dfe-brand-accent-colour;
 
 .app-breadcrumbs--inverted {
   @include govuk-responsive-margin(6, "bottom");

--- a/app/_components/footer/_footer.scss
+++ b/app/_components/footer/_footer.scss
@@ -1,0 +1,4 @@
+.app-footer {
+  border-color: $dfe-mid-grey;
+  background-color: govuk-colour("white");
+}

--- a/app/_components/footer/macro.njk
+++ b/app/_components/footer/macro.njk
@@ -1,0 +1,3 @@
+{% macro appFooter(params) %}
+  {%- include "./template.njk" -%}
+{% endmacro %}

--- a/app/_components/footer/template.njk
+++ b/app/_components/footer/template.njk
@@ -1,0 +1,18 @@
+<footer class="govuk-footer app-footer govuk-!-display-none-print" role="contentinfo">
+  <div class="govuk-width-container">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+        <h2 class="govuk-visually-hidden">{{ params.meta.visuallyHiddenTitle or "Support links" }}</h2>
+        {% if params.meta.items %}
+          <ul class="govuk-footer__inline-list">
+          {% for item in params.meta.items %}
+            <li class="govuk-footer__inline-list-item">
+              <a class="govuk-footer__link" href="{{ item.href }}">{{ item.text }}</a>
+            </li>
+          {% endfor %}
+          </ul>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</footer>

--- a/app/_components/header/_header.scss
+++ b/app/_components/header/_header.scss
@@ -2,6 +2,27 @@
 // See: https://github.com/alphagov/govuk-design-system/blob/master/src/stylesheets/components/_header.scss
 
 @include govuk-exports("app-header") {
+  .app-header {
+    color: $govuk-text-colour;
+    background-color: white;
+    border-color: $dfe-light-grey;
+  }
+
+  .govuk-header__link:link,
+  .govuk-header__link:visited {
+    color: inherit;
+  }
+
+  .govuk-header__link--homepage,
+  .govuk-header__product-name {
+    @include govuk-font(19);
+    font-weight: 600;
+  }
+
+  .govuk-header__container {
+    border-color: $dfe-brand-colour;
+  }
+
   // Override the default 33% width on the logo in GOV.UK Frontend (prevents
   // unnecessary wrapping of app.productName on smaller tablet / desktop
   // viewports)

--- a/app/_components/header/template.njk
+++ b/app/_components/header/template.njk
@@ -3,44 +3,6 @@
   <div class="govuk-header__container govuk-width-container app-header__container">
     <div class="govuk-header__logo app-header__logo">
       <a href="{{ params.homepageUrl | default('/') }}" class="govuk-header__link govuk-header__link--homepage">
-        <span class="govuk-header__logotype">
-          {#- We use an inline SVG for the crown so that we can cascade the
-          currentColor into the crown whilst continuing to support older browsers
-          which do not support external SVGs without a Javascript polyfill. This
-          adds approximately 1kb to every page load.
-          We use currentColour so that we can easily invert it when printing and
-          when the focus state is applied. This also benefits users who override
-          colours in their browser as they will still see the crown.
-          The SVG needs `focusable="false"` so that Internet Explorer does not
-          treat it as an interactive element - without this it will be
-          'focusable' when using the keyboard to navigate. #}
-          <svg
-            role="presentation"
-            focusable="false"
-            class="govuk-header__logotype-crown"
-            xmlns="http://www.w3.org/2000/svg"
-            viewbox="0 0 132 97"
-            height="30"
-            width="36"
-          >
-            <path
-              fill="currentColor" fill-rule="evenodd"
-              d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z"
-            ></path>
-            {#- Fallback PNG image for older browsers.
-            The <image> element is a valid SVG element. In SVG, you would specify
-            the URL of the image file with the xlink:href – as we don't reference an
-            image it has no effect. It's important to include the empty xlink:href
-            attribute as this prevents versions of IE which support SVG from
-            downloading the fallback image when they don't need to.
-            In other browsers <image> is synonymous for the <img> tag and will be
-            interpreted as such, displaying the fallback image. #}
-            <image src="/assets/images/govuk-logotype-crown.png" xlink:href="" class="govuk-header__logotype-crown-fallback-image" width="36" height="32"></image>
-          </svg>
-          <span class="govuk-header__logotype-text">
-            GOV.UK
-          </span>
-        </span>
         {% if (params.productName) %}
         <span class="govuk-header__product-name">
           {{ params.productName }}

--- a/app/_components/masthead/_masthead.scss
+++ b/app/_components/masthead/_masthead.scss
@@ -2,7 +2,7 @@
   @include govuk-responsive-padding(6, "top");
   @include govuk-responsive-padding(6, "bottom");
   color: govuk-colour("white");
-  background-color: govuk-colour("blue");
+  background-color: $dfe-brand-colour;
   margin-top: #{govuk-spacing(2) * -1};
 }
 

--- a/app/_components/related/_related.scss
+++ b/app/_components/related/_related.scss
@@ -1,5 +1,5 @@
 .app-related {
-  border-top: 2px solid govuk-colour("blue");
+  border-top: 2px solid $dfe-brand-colour;
   padding-top: govuk-spacing(3);
 }
 

--- a/app/_components/site-search/_site-search.scss
+++ b/app/_components/site-search/_site-search.scss
@@ -168,7 +168,7 @@ $icon-size: 40px;
   .app-site-search__hint,
   .app-site-search__input,
   .app-site-search__option {
-    @include govuk-font($size: 19);
+    @include govuk-font($size: 16);
   }
 
   .app-site-search__link {

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -2,8 +2,9 @@
 
 {% set htmlClasses = 'no-js' %}
 
-{% from "header/macro.njk" import appHeader %}
 {% from "breadcrumbs/macro.njk" import appBreadcrumbs %}
+{% from "footer/macro.njk" import appFooter %}
+{% from "header/macro.njk" import appHeader %}
 
 {% block head %}
 <!--[if lte IE 8]><link href="/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
@@ -38,7 +39,7 @@
 
 {% block footer %}
   <div class="govuk-!-display-none-print">
-    {{ govukFooter({
+    {{ appFooter({
       meta: {
         items: [{
           text: "Sitemap",

--- a/app/_stylesheets/application.scss
+++ b/app/_stylesheets/application.scss
@@ -1,5 +1,133 @@
+@import url("https://rsms.me/inter/inter.css");
+
+// DfE colours
+$dfe-brand-colour: #003a69;
+$dfe-brand-accent-colour: #1d70b8; // govuk-colour("blue")
+$dfe-brand-colour: #003a69;
+$dfe-light-grey: #f5f5f5;
+$dfe-mid-grey: #cbcbcb;
+
 // GOV.UK Frontend styles
 $govuk-global-styles: true;
+$govuk-font-family: "Inter", sans-serif;
+$govuk-body-background-colour: $dfe-light-grey;
+$govuk-link-colour: $dfe-brand-colour;
+$govuk-link-hover-colour: $dfe-brand-accent-colour;
+$govuk-typography-scale: (
+  80: (
+    null: (
+      font-size: 53px,
+      line-height: 55px
+    ),
+    tablet: (
+      font-size: 80px,
+      line-height: 80px
+    ),
+    print: (
+      font-size: 53pt,
+      line-height: 1.1
+    )
+  ),
+  48: (
+    null: (
+      font-size: 32px,
+      line-height: 1.3
+    ),
+    tablet: (
+      font-size: 40px,
+      line-height: 1.3
+    ),
+    print: (
+      font-size: 32pt,
+      line-height: 1.15
+    )
+  ),
+  36: (
+    null: (
+      font-size: 24px,
+      line-height: 1.3
+    ),
+    tablet: (
+      font-size: 32px,
+      line-height: 1.3
+    ),
+    print: (
+      font-size: 24pt,
+      line-height: 1.05
+    )
+  ),
+  27: (
+    null: (
+      font-size: 18px,
+      line-height: 20px
+    ),
+    tablet: (
+      font-size: 27px,
+      line-height: 30px
+    ),
+    print: (
+      font-size: 18pt,
+      line-height: 1.15
+    )
+  ),
+  24: (
+    null: (
+      font-size: 18px,
+      line-height: 1.3
+    ),
+    tablet: (
+      font-size: 24px,
+      line-height: 1.3
+    ),
+    print: (
+      font-size: 18pt,
+      line-height: 1.15
+    )
+  ),
+  19: (
+    null: (
+      font-size: 15px,
+      line-height: 1.35
+    ),
+    tablet: (
+      font-size: 18px,
+      line-height: 1.45
+    ),
+    print: (
+      font-size: 14pt,
+      line-height: 1.15
+    )
+  ),
+  16: (
+    null: (
+      font-size: 14px,
+      line-height: 16px
+    ),
+    tablet: (
+      font-size: 16px,
+      line-height: 20px
+    ),
+    print: (
+      font-size: 14pt,
+      line-height: 1.2
+    )
+  ),
+  14: (
+    null: (
+      font-size: 12px,
+      line-height: 15px
+    ),
+    tablet: (
+      font-size: 14px,
+      line-height: 20px
+    ),
+    print: (
+      font-size: 12pt,
+      line-height: 1.2
+    )
+  )
+);
+
 @import "govuk/all.scss";
 
 // Design History styles


### PR DESCRIPTION
In response #306, thought about using Home Office frontend kit, but it’s not very easy to use, unfortunately (makes lots of assumptions). But looking at it, can probably change much of the design by overriding some GOV.UK Frontend defaults.

I dunno, could just remove the crown and font, but this might work too. Thoughts?