### PR TITLE
Link to glossary from homepage

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -52,9 +52,6 @@
         }, {
           text: "Wiki",
           href: "https://dfedigital.atlassian.net/wiki/spaces/BaT/overview"
-        }, {
-          text: "Glossary",
-          href: "/glossary"
         }]
       }
     }) }}

--- a/app/_layouts/collection.njk
+++ b/app/_layouts/collection.njk
@@ -80,6 +80,15 @@
               <p class="govuk-body">{{ item.excerpt }}</p>
             </section>
           {% endfor %}
+          <div class="govuk-grid-column-full">
+            <h2 class="govuk-heading-l govuk-!-font-size-27">
+              Support
+            </h2>
+          </div>
+          <div class="govuk-grid-column-one-half govuk-!-margin-bottom-6">
+            <h3 class="govuk-heading-m govuk-!-margin-bottom-1"><a class="govuk-link" href="/glossary">A to Z glossary</a></h3>
+            <p class="govuk-body">A guide to terms used across the services</p>
+          </div>
         {% endif %}
       </div>
     {% endblock %}

--- a/app/glossary.md
+++ b/app/glossary.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Glossary
+title: A to Z glossary
 description: A collection of terms commonly used across the Becoming a Teacher service lines.
 permalink: "/glossary.html"
 ---


### PR DESCRIPTION
The glossary feels a bit hidden in the footer, but is super useful.

I've kept the other links in the footer, as they all link to external websites.

Link and text is hardcoded, but if there’s a way to do this neatly within Eleventy I’m all ears.