### PR TITLE
Update footer links

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -37,19 +37,18 @@
 {% set mainClasses = mainClasses | default("govuk-main-wrapper--auto-spacing") %}
 
 {% block footer %}
-  <div class="govuk-!-display-none-print">
-    {{ govukFooter({
-      meta: {
-        items: [{
-          text: "Sitemap",
-          href: "/sitemap"
-        }, {
-          text: "GitHub",
-          href: "https://github.com/dfe-digital/bat-design-history"
-        }]
-      }
-    }) }}
-  </div>
+  {{ govukFooter({
+    classes: "govuk-!-display-none-print",
+    meta: {
+      items: [{
+        text: "Sitemap",
+        href: "/sitemap"
+      }, {
+        text: "GitHub",
+        href: "https://github.com/dfe-digital/bat-design-history"
+      }]
+    }
+  }) }}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -44,14 +44,8 @@
           text: "Sitemap",
           href: "/sitemap"
         }, {
-          text: "Support playbook",
-          href: "https://docs.google.com/document/d/1SV2HWQgRM46dLLEEXHsGADqj1p04Vk6rOcC5VvbDa3A/edit"
-        }, {
-          text: "Support model",
-          href: "https://docs.google.com/document/d/1akzv0scmArgVtGcIqYstoQUTXXd823uQBd3SsFK1Ow8/edit"
-        }, {
-          text: "Wiki",
-          href: "https://dfedigital.atlassian.net/wiki/spaces/BaT/overview"
+          text: "GitHub",
+          href: "https://github.com/dfe-digital/bat-design-history"
         }]
       }
     }) }}


### PR DESCRIPTION
Links in the footer are not relevant (support model/playbook) or useful/accessible (Confluence wiki).

* Updates links in footer to Sitemap and this repo
* Correctly adds `govuk-!-display-none-print` class to footer component