### PR TITLE
Use relative image paths

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,10 +35,8 @@ module.exports = function (eleventyConfig) {
 
   // Passthrough
   eleventyConfig.addPassthroughCopy('./app/documents')
-  eleventyConfig.addPassthroughCopy('./app/images')
-  eleventyConfig.addPassthroughCopy({
-    'node_modules/govuk-frontend/govuk/assets': 'assets'
-  })
+  eleventyConfig.addPassthroughCopy({'./app/images': '.'})
+  eleventyConfig.addPassthroughCopy({'node_modules/govuk-frontend/govuk/assets': 'assets'})
 
   // Enable data deep merge
   eleventyConfig.setDataDeepMerge(true)

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,8 +35,8 @@ module.exports = function (eleventyConfig) {
 
   // Passthrough
   eleventyConfig.addPassthroughCopy('./app/documents')
-  eleventyConfig.addPassthroughCopy({'./app/images': '.'})
-  eleventyConfig.addPassthroughCopy({'node_modules/govuk-frontend/govuk/assets': 'assets'})
+  eleventyConfig.addPassthroughCopy({ './app/images': '.' })
+  eleventyConfig.addPassthroughCopy({ 'node_modules/govuk-frontend/govuk/assets': 'assets' })
 
   // Enable data deep merge
   eleventyConfig.setDataDeepMerge(true)

--- a/app/_components/figure/template.njk
+++ b/app/_components/figure/template.njk
@@ -1,5 +1,4 @@
 {%- from "../embed/macro.njk" import appEmbed with context -%}
-{%- from "../image/macro.njk" import appImage with context -%}
 <figure class="app-figure">
 {% if params.title %}
   <figcaption class="govuk-heading-s">
@@ -15,11 +14,9 @@
   }) | indent(2) }}
 {% endif %}
 {% if params.image %}
-  {{ appImage({
-    path: params.image.path,
-    file: params.image.file,
-    alt: params.image.alt
-  }) | indent(2) }}
+  <a href="{{ params.image.file }}">
+    <img src="{{ params.image.file }}" alt="{{ params.image.alt }}">
+  </a>
 {% endif %}
 {% if params.caption %}
   <figcaption class="app-figure__caption app-prose">

--- a/app/_components/gallery/template.njk
+++ b/app/_components/gallery/template.njk
@@ -7,7 +7,6 @@
   <li class="app-gallery__item" id="{{ id }}">
     {{ appFigure({
       image: {
-        path: params.path,
         file: file,
         alt: alt
       },

--- a/app/_components/screenshots/template.njk
+++ b/app/_components/screenshots/template.njk
@@ -24,7 +24,6 @@
     {{ appFigure({
       id: id,
       image: {
-        path: params.path or item.img.path,
         file: file,
         alt: alt
       },

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -10,7 +10,7 @@
 <!--[if gt IE 8]><!--><link href="/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 <meta property="og:title" content="{{ title }}">
 {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
-<meta property="og:image" content="/images/opengraph-image.png">
+<meta property="og:image" content="/opengraph-image.png">
 <meta name="robots" content="noindex nofollow">
 {% endblock %}
 

--- a/app/mission-patches.md
+++ b/app/mission-patches.md
@@ -2,7 +2,6 @@
 layout: page
 title: Mission patches
 description: Archive of patches created to celebrate milestones in the development of our different services.
-permalink: "/mission-patches.html"
 tags: reference
 eleventyComputed:
   eleventyNavigation:
@@ -22,7 +21,6 @@ eleventyComputed:
 The mascot for Apply (and Manage) is a beaver named Brian Townley. We chose a beaver because we are building a complex service and delivering it in the rapid-flowing waters of the ever-changing initial teacher training market.
 
 {{ appGallery({
-  path: "/images/mission-patches",
   items: [{
     text: "Apply for teacher training SCITT Pilot",
     caption: "This patch celebrated the tenacity of our team, who despite a power cut and several building evacuations, launched the service from a nearby pub. November 2019"
@@ -45,7 +43,6 @@ The mascot for Apply (and Manage) is a beaver named Brian Townley. We chose a be
 The mascot for Find (and Publish) is a canary. When we launched Publish we weren’t sure how much our recent integration with DfE Sign-in would work. Our first few providers were used as [canaries](https://en.wikipedia.org/wiki/Sentinel_species) to test if they could access service – we had many dead canaries until we got the process right and could roll out the service to everyone.
 
 {{ appGallery({
-  path: "/images/mission-patches",
   items: [{
     text: "Find teacher training beta",
     caption: "This patch celebrated the launch of the Find service moving into its beta phase. November 2018"
@@ -67,7 +64,6 @@ The mascot for Register is an octopus called Inky. We chose an octopus because t
 The team was formed during a period where they couldn’t be physically near, so just like an octopus, they reached with curiosity to connect with those around them.
 
 {{ appGallery({
-  path: "/images/mission-patches",
   items: [{
     text: "Register trainee teachers private beta",
     caption: "This patch celebrated the service entering private beta with a junior octopus to represent an emerging service. September 2020"
@@ -79,7 +75,6 @@ The team was formed during a period where they couldn’t be physically near, so
 ## Other projects
 
 {{ appGallery({
-  path: "/images/mission-patches",
   items: [{
     text: "Allocations discovery",
     caption: "This patch captured the team trying to find their way. The allocations discovery was a confusing time with complex problems to solve. A fox was chosen for their cleverness but also because a team member’s last name was Fox. January 2020"

--- a/app/posts/apply-for-teacher-training/2018-04-30-apply-april-2018.md
+++ b/app/posts/apply-for-teacher-training/2018-04-30-apply-april-2018.md
@@ -18,11 +18,7 @@ One of the options for private beta is to use UCAS as the back end for our servi
 
 ### Application
 
-{% from "image/macro.njk" import appImage with context %}
-{{ appImage({
-  file: "application.png",
-  alt: "Screenshot of Application"
-}) }}
+![Screenshot of Application](application.png)
 
 [Link to prototype](https://bat-apply.herokuapp.com/v01/application)
 
@@ -34,10 +30,7 @@ One of the options for private beta is to use UCAS as the back end for our servi
 
 ### Application summary (full)
 
-{{ appImage({
-  file: "application-summary-full.png",
-  alt: "Screenshot of Application summary (full)"
-}) }}
+![Screenshot of Application summary (full)](application-summary-full.png)
 
 [Link to prototype](https://bat-apply.herokuapp.com/v01/application/applicationSummary)
 
@@ -53,10 +46,7 @@ This will be maximum a set of data the providers would need to know in an applic
 
 ### Application summary (reduced)
 
-{{ appImage({
-  file: "application-summary-reduced.png",
-  alt: "Screenshot of Application summary (reduced)"
-}) }}
+![Screenshot of Application summary (reduced)](application-summary-reduced.png)
 
 [Link to prototype](https://bat-apply.herokuapp.com/v01/application/applicationSummary_strippedDown)
 

--- a/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
+++ b/app/posts/apply-for-teacher-training/2019-08-19-no-teaching-profile.md
@@ -38,20 +38,17 @@ This alternative creates a simpler application process that is also easier to bu
   items: [{
     text: "Application with courses",
     img: {
-      path: "/images/apply-for-teacher-training/pick-a-course",
-      src: "your-application.png"
+      src: "/apply-for-teacher-training/pick-a-course/your-application.png"
     }
   }, {
     text: "Old dashboard",
     img: {
-      path: "/images/apply-for-teacher-training/apply-june-2019/personal-details",
-      src: "dashboard.png"
+      src: "/apply-for-teacher-training/apply-june-2019/personal-details/dashboard.png"
     }
   }, {
     text: "Old personal teaching profile",
     img: {
-      path: "/images/apply-for-teacher-training/apply-june-2019/personal-details",
-      src: "personal-teaching-profile.png"
+      src: "/apply-for-teacher-training/apply-june-2019/personal-details/personal-teaching-profile.png"
     }
   }]
 }) }}

--- a/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
+++ b/app/posts/apply-for-teacher-training/2019-10-23-find-to-apply.md
@@ -23,7 +23,7 @@ To skip the start page, the content on the Apply and Find start pages must be co
 
 ## User journey
 
-![User journey diagram](/images/apply-for-teacher-training/find-to-apply/find-to-apply-journey.svg)
+![User journey diagram](/apply-for-teacher-training/find-to-apply/find-to-apply-journey.svg)
 
 [Google drawing](https://docs.google.com/drawings/d/1d30V3qtVYQNL_gWIMuGjgjm2doWMIDyIyYWchIKnPe8)
 

--- a/app/posts/apply-for-teacher-training/2020-10-06-end-of-cycle-and-carry-over.md
+++ b/app/posts/apply-for-teacher-training/2020-10-06-end-of-cycle-and-carry-over.md
@@ -15,16 +15,14 @@ For example, we informed candidates about upcoming application deadlines and adv
 {% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/end-of-cycle/",
-    file: "your-application-with-first-deadline.png",
+    file: "/apply-for-teacher-training/end-of-cycle/your-application-with-first-deadline.png",
     alt: "Screenshot of a banner informing candidates of the upcoming deadline for applications."
   }
 }) }}
 
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/end-of-cycle/",
-    file: "your-application-with-second-deadline.png",
+    file: "/apply-for-teacher-training/end-of-cycle/your-application-with-second-deadline.png",
     alt: "Screenshot of a banner informing candidates of the upcoming deadline for applying again."
   }
 }) }}
@@ -33,8 +31,7 @@ We also started to think about how to communicate with candidates once deadlines
 
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/end-of-cycle/",
-    file: "application-dashboard-with-opening-date.png",
+    file: "/apply-for-teacher-training/end-of-cycle/application-dashboard-with-opening-date.png",
     alt: "Screenshot of a banner informing candidates that applications for courses starting in this academic year have now closed."
   }
 }) }}
@@ -55,8 +52,7 @@ Candidates have to initiate applying again, like they do in the existing journey
 
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/apply-again/",
-    file: "01-apply-again-banner.png",
+    file: "/apply-for-teacher-training/apply-again/01-apply-again-banner.png",
     alt: "Screenshot of ‘Application dashboard’ with banner asking candidate if they want to apply again."
   },
   caption: "Within a recruitment cycle, a candidate is asked “Do you want to apply again”?"
@@ -64,8 +60,7 @@ Candidates have to initiate applying again, like they do in the existing journey
 
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/apply-again/",
-    file: "02-apply-again-page.png",
+    file: "/apply-for-teacher-training/apply-again/02-apply-again-page.png",
     alt: "Screenshot of interstitial page explaining to candidate how applying again works."
   },
   caption: "If they click the link, an intersitital page explains how applying again works."
@@ -73,8 +68,7 @@ Candidates have to initiate applying again, like they do in the existing journey
 
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/applying-again-iteration/",
-    file: "banner.png",
+    file: "/apply-for-teacher-training/applying-again-iteration/banner.png",
     alt: "Screenshot of ‘Your new application’ page with banner that informs the candidate that we’ve copied their application."
   },
   caption: "If they click ‘Start now’, we show them their new application, with information copied over from their last one."

--- a/app/posts/apply-for-teacher-training/2020-10-30-feedback-component.md
+++ b/app/posts/apply-for-teacher-training/2020-10-30-feedback-component.md
@@ -21,8 +21,7 @@ GOV.​UK uses a component that may help us achieve this. The [feedback componen
 {% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/feedback-component/",
-    file: "govuk-component.png",
+    file: "/apply-for-teacher-training/feedback-component/govuk-component.png",
     alt: "Screenshot of a banner informing candidates of the upcoming deadline for applications."
   }
 }) }}

--- a/app/posts/apply-for-teacher-training/2021-03-30-a-levels.md
+++ b/app/posts/apply-for-teacher-training/2021-03-30-a-levels.md
@@ -29,8 +29,7 @@ We also added some hint text to ‘Other qualifications’ to help people identi
 {% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/a-levels/",
-    file: "application-sections-iteration-1.png",
+    file: "/apply-for-teacher-training/a-levels/application-sections-iteration-1.png",
     alt: "‘Your application’ with updated section structure."
   }
 }) }}
@@ -49,8 +48,7 @@ We re-ordered the ‘Qualifications’ section, taking account of the mental mod
 
 {{ appFigure({
   image: {
-    path: "/images/apply-for-teacher-training/a-levels/",
-    file: "application-sections-iteration-2.png",
+    file: "/apply-for-teacher-training/a-levels/application-sections-iteration-2.png",
     alt: "‘Your application’ with revised section structure."
   }
 }) }}

--- a/app/posts/apply-for-teacher-training/ucas/coronavirus.md
+++ b/app/posts/apply-for-teacher-training/ucas/coronavirus.md
@@ -11,5 +11,5 @@ This is the email UCAS sent to providers:
 
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
-  content: "![Changes to decline by default (DBD) and reject by default (RBD) dates, and updating vacancy statuses](/images/apply-for-teacher-training/ucas/coronavirus/change-to-deadlines.png)"
+  content: "![Changes to decline by default (DBD) and reject by default (RBD) dates, and updating vacancy statuses](/apply-for-teacher-training/ucas/coronavirus/change-to-deadlines.png)"
 }) }}

--- a/app/posts/apply-for-teacher-training/ucas/emails.md
+++ b/app/posts/apply-for-teacher-training/ucas/emails.md
@@ -10,19 +10,19 @@ With an application started in March 2019, the following emails were sent over t
 {% from "email/macro.njk" import appEmail %}
 {{ appEmail({
   subject: "((first_name)), here’s what you need to do now",
-  content: "![Now you’ve started your UCAS Teacher Training application, you’re one step closer to becoming a teacher.](/images/apply-for-teacher-training/ucas/emails/day1.png)"
+  content: "![Now you’ve started your UCAS Teacher Training application, you’re one step closer to becoming a teacher.](/apply-for-teacher-training/ucas/emails/day1.png)"
 }) }}
 
 ## 1 week after starting an application
 
 {{ appEmail({
   subject: "((first_name)), make your application stand out",
-  content: "![It’s been just over a week since you started your UCAS Teacher Training application…](/images/apply-for-teacher-training/ucas/emails/day7.png)"
+  content: "![It’s been just over a week since you started your UCAS Teacher Training application…](/apply-for-teacher-training/ucas/emails/day7.png)"
 }) }}
 
 ## 3 weeks after starting an application
 
 {{ appEmail({
   subject: "((first_name)), it’s time to apply",
-  content: "![We’ve got loads of support to help you with your application](/images/apply-for-teacher-training/ucas/emails/day21.png)"
+  content: "![We’ve got loads of support to help you with your application](/apply-for-teacher-training/ucas/emails/day21.png)"
 }) }}

--- a/app/posts/find-teacher-training/2018-10-02-fe-and-pgde.md
+++ b/app/posts/find-teacher-training/2018-10-02-fe-and-pgde.md
@@ -57,15 +57,14 @@ This qualification is at level lower than PGCE. It is mostly relevant in the FE 
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
-  path: "/images/find-teacher-training/live-launch",
   items: [{
     text: "Qualification filter",
-    img: { src: "qualification-filter.png" }
+    img: { src: "/find-teacher-training/live-launch/qualification-filter.png" }
   }, {
     text: "Further education search results",
-    img: { src: "further-education-results.png" }
+    img: { src: "/find-teacher-training/live-launch/further-education-results.png" }
   }, {
     text: "Full course page (PGDE)",
-    img: { src: "full-course-page-pgde.png" }
+    img: { src: "/find-teacher-training/live-launch/full-course-page-pgde.png" }
   }]
 }) }}

--- a/app/posts/find-teacher-training/2018-11-21-tweaked-course-titles.md
+++ b/app/posts/find-teacher-training/2018-11-21-tweaked-course-titles.md
@@ -4,7 +4,7 @@ description: Make it easier to differentiate between search results.
 date: 2018-11-21
 ---
 
-Search results must be distinct, and the differences between courses must be clear. When a provider offers multiple courses for the same subject, it’s not obvious to users what the difference is ([see BHSSA example](/images/find-teacher-training/live-launch/search-results.png)).
+Search results must be distinct, and the differences between courses must be clear. When a provider offers multiple courses for the same subject, it’s not obvious to users what the difference is ([see BHSSA example](/find-teacher-training/live-launch/search-results.png)).
 
 Make courses more obviously different by:
 

--- a/app/posts/find-teacher-training/2020-10-30-feedback-component.md
+++ b/app/posts/find-teacher-training/2020-10-30-feedback-component.md
@@ -14,8 +14,7 @@ We currently ask users for feedback, or to report any problems, in the final two
 {% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: "/images/find-teacher-training/feedback-component/",
-    file: "existing-content.png",
+    file: "/find-teacher-training/feedback-component/existing-content.png",
     alt: "Existing content shown on course pages."
   }
 }) }}

--- a/app/posts/find-teacher-training/2021-02-10-searching-by-location-iteration.md
+++ b/app/posts/find-teacher-training/2021-02-10-searching-by-location-iteration.md
@@ -166,8 +166,7 @@ The boxouts colour bar has changed from GIT green to GOV.UK blue.
 
 {{ appFigure({
   image: {
-    path: "/images/find-teacher-training/searching-by-location",
-    file: "standardised-guidance-school-placements.png"
+    file: "/find-teacher-training/searching-by-location/standardised-guidance-school-placements.png"
   },
   caption: "Previous design for standardised guidance."
 }) }}

--- a/app/posts/manage-teacher-training-applications/2020-03-05-tracking-conditions-individually.md
+++ b/app/posts/manage-teacher-training-applications/2020-03-05-tracking-conditions-individually.md
@@ -7,7 +7,6 @@ tags:
 ---
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}
-{% from "image/macro.njk" import appImage with context %}
 
 {{description}}
 

--- a/app/posts/manage-teacher-training-applications/2020-08-06-diversity-information.md
+++ b/app/posts/manage-teacher-training-applications/2020-08-06-diversity-information.md
@@ -10,8 +10,6 @@ related:
     href: /apply-for-teacher-training/apply-september-2019/#equality-and-diversity
 ---
 
-{% from "image/macro.njk" import appImage with context %}
-
 In March we started collecting equality and diversity information from candidates. This is an optional questionnaire that we ask candidates to complete to reduce discrimination on the basis of sex, disability and ethnicity.
 
 We’ll only make this information available to providers once an application is complete.
@@ -36,19 +34,13 @@ We want providers to be clear what information is available, but also why they c
 
 We explored adding additional rows to the applicant details summary list, but with a placeholder line if they couldn’t be shown.
 
-{{ appImage({
-  file: 'multiple-lines-short-grey.png',
-  alt: '3 lines in a summary list, with grey text that reads ‘Only available when the candidate accepts your offer’'
-})}}
+![3 lines in a summary list, with grey text that reads ‘Only available when the candidate accepts your offer’](multiple-lines-short-grey.png)
 
 Once you add multiple rows it gets somewhat repetitive. We tried making them grey to knock them back a bit - and because they’re more of a message from the system than a candidate’s answer.
 
 For users without the correct permissions the text isn’t quite right - so they need more explanation.
 
-{{ appImage({
-  file: 'multiple-lines-long-grey.png',
-  alt: '3 lines in a summary list, with grey text that reads ‘Only available to users with ‘view diversity information’ permission once an offer has been accepted’'
-})}}
+![3 lines in a summary list, with grey text that reads ‘Only available to users with ‘view diversity information’ permission once an offer has been accepted’](multiple-lines-long-grey.png)
 
 ## Second iteration
 

--- a/app/posts/publish-teacher-training-courses/2018-05-24-what-is-a-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-05-24-what-is-a-course.md
@@ -36,19 +36,19 @@ What’s the difference between:
 
 ## Examples of the problem
 
-![Screenshot of private beta search results. Two very similar search results in private beta. One is full time and one is part time.](/images/publish-teacher-training-courses/ucas-examples/private-beta-problem-01.png)
+![Screenshot of private beta search results. Two very similar search results in private beta. One is full time and one is part time.](/publish-teacher-training-courses/ucas-examples/private-beta-problem-01.png)
 
 Two very similar search results in private beta. One is full time and one is part time.
 
-![Screenshot of private beta search results. Two identical search results in private beta. One is PGCE with QTS, the other is QTS only.](/images/publish-teacher-training-courses/ucas-examples/private-beta-problem-02.png)
+![Screenshot of private beta search results. Two identical search results in private beta. One is PGCE with QTS, the other is QTS only.](/publish-teacher-training-courses/ucas-examples/private-beta-problem-02.png)
 
 Two identical search results in private beta. One is PGCE with QTS, the other is QTS only.
 
-![Screenshot of UCAS search results. A similar problem with UCAS – 6 courses, one per school.](/images/publish-teacher-training-courses/ucas-examples/ucas-problem-01.png)
+![Screenshot of UCAS search results. A similar problem with UCAS – 6 courses, one per school.](/publish-teacher-training-courses/ucas-examples/ucas-problem-01.png)
 
 A similar problem with UCAS – 6 courses, one per school.
 
-![Screenshot of UCAS search results. Another UCAS example – four courses, different accrediting providers, two salaried and two unsalaried.](/images/publish-teacher-training-courses/ucas-examples/ucas-problem-02.png)
+![Screenshot of UCAS search results. Another UCAS example – four courses, different accrediting providers, two salaried and two unsalaried.](/publish-teacher-training-courses/ucas-examples/ucas-problem-02.png)
 
 Another UCAS example – four courses, different accrediting providers, two salaried and two unsalaried.
 

--- a/app/posts/publish-teacher-training-courses/2018-08-01-story-map-aug-1.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-01-story-map-aug-1.md
@@ -28,8 +28,7 @@ Show the end to end journey, from publishing and enriching courses to search and
   }, {
     text: "Publishing a course",
     img: {
-      path: "/images/publish-teacher-training-courses/validating-on-publish",
-      src: "validating-a-course-on-publish.png"
+      src: "/publish-teacher-training-courses/validating-on-publish/validating-a-course-on-publish.png"
     }
   }, {
     text: "Service start page",

--- a/app/posts/publish-teacher-training-courses/2018-08-09-no-more-folding.md
+++ b/app/posts/publish-teacher-training-courses/2018-08-09-no-more-folding.md
@@ -68,18 +68,17 @@ We’re [tracking grouping on the story map](https://trello.com/c/jQftifYl/44-gr
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
-  path: "/images/publish-teacher-training-courses/unfolded-courses",
   items: [{
     text: "Organisation",
-    img: { src: "organisation.png" }
+    img: { src: "/publish-teacher-training-courses/unfolded-courses/organisation.png" }
   }, {
     text: "Course: PGCE with QTS full time with salary",
-    img: { src: "pgce-with-qts-full-time-with-salary.png" }
+    img: { src: "/publish-teacher-training-courses/unfolded-courses/pgce-with-qts-full-time-with-salary.png" }
   }, {
     text: "Course: PGCE with QTS full time",
-    img: { src: "pgce-with-qts-full-time.png" }
+    img: { src: "/publish-teacher-training-courses/unfolded-courses/pgce-with-qts-full-time.png" }
   }, {
     text: "About your organisation",
-    img: { src: "about-your-organisation.png" }
+    img: { src: "/publish-teacher-training-courses/unfolded-courses/about-your-organisation.png" }
   }]
 }) }}

--- a/app/posts/publish-teacher-training-courses/2018-10-15-course-not-running-oct-15.md
+++ b/app/posts/publish-teacher-training-courses/2018-10-15-course-not-running-oct-15.md
@@ -33,7 +33,7 @@ The course is not published yet because candidates can’t apply to it. It can�
 
 On the organisation page any course with the status ‘Needs attention on UCAS’ should have that status displayed in red and bold to drawn attention to it. The status should link to the course page:
 
-![Screenshot showing needs attention on UCAS status](/images/publish-teacher-training-courses/needs-attention-status.png)
+![Screenshot showing needs attention on UCAS status](/publish-teacher-training-courses/needs-attention-status.png)
 
 ### 3\. New - not yet running
 

--- a/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
+++ b/app/posts/publish-teacher-training-courses/2018-12-14-new-course.md
@@ -45,7 +45,7 @@ If the course is marked as a special educational needs one, it’s appended to t
 
 ## New course workflow
 
-![New course workflow](/images/publish-teacher-training-courses/new-course/workflow.png)
+![New course workflow](/publish-teacher-training-courses/new-course/workflow.png)
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({

--- a/app/posts/publish-teacher-training-courses/2019-01-29-edit-course-workflow.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-29-edit-course-workflow.md
@@ -12,4 +12,4 @@ For most questions this is ok, but for some there’s a knock-on effect to furth
 
 The diagram below documents which questions are simple, and which affect other questions. ([Google diagram](https://docs.google.com/drawings/d/1OrJYSTmRSJD2GEAWFnr2lXLNo7A9J9GDsPMQUm0Pi0M/edit))
 
-![Edit course workflow](/images/publish-teacher-training-courses/edit-course-workflow/workflow.svg)
+![Edit course workflow](/publish-teacher-training-courses/edit-course-workflow/workflow.svg)

--- a/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-13-accredited-body-iteration.md
@@ -21,8 +21,7 @@ Update the design so that:
   }, {
     text: "Old design",
     img: {
-      path: "/images/publish-teacher-training-courses/new-course-iteration-14-jan",
-      src: "who-is-the-accredited-body.png"
+      src: "/publish-teacher-training-courses/new-course-iteration-14-jan/who-is-the-accredited-body.png"
     }
   }]
 }) }}

--- a/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-14-languages-iteration.md
@@ -22,8 +22,7 @@ The original design only catered for the dominant use case. For MVP we can ask f
   }, {
     text: "Original design",
     img: {
-      path: "/images/publish-teacher-training-courses/new-course-iteration-14-jan",
-      src: "pick-languages.png"
+      src: "/publish-teacher-training-courses/new-course-iteration-14-jan/pick-languages.png"
     }
   }]
 }) }}

--- a/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
+++ b/app/posts/publish-teacher-training-courses/2019-02-26-onboarding-wizard.md
@@ -16,7 +16,7 @@ Workflow co-designed with UCAS.
 
 [Prototype](https://publish-courses-prototype.herokuapp.com/onboarding/accept-terms)
 
-[![Onboarding workflow](/images/publish-teacher-training-courses/onboarding-wizard/onboarding-workflow.svg)](https://docs.google.com/drawings/d/12slZCbsAB8m0-T9s_QGmqFZRxhwF1KfkoiN2g4Xk0mY/edit)
+[![Onboarding workflow](/publish-teacher-training-courses/onboarding-wizard/onboarding-workflow.svg)](https://docs.google.com/drawings/d/12slZCbsAB8m0-T9s_QGmqFZRxhwF1KfkoiN2g4Xk0mY/edit)
 
 ### Lead schools
 

--- a/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-20-course-tabs.md
@@ -33,8 +33,7 @@ By splitting the page into tabs we:
 {% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: "/images/publish-teacher-training-courses/deleting-and-withdrawing",
-    file: "course-that-can-be-deleted.png"
+    file: "/publish-teacher-training-courses/deleting-and-withdrawing/course-that-can-be-deleted.png"
   },
   caption: "Delete link has been added to the bottom of the status column."
 }) }}

--- a/app/posts/publish-teacher-training-courses/2019-03-24-minimum-requirements-iterations.md
+++ b/app/posts/publish-teacher-training-courses/2019-03-24-minimum-requirements-iterations.md
@@ -20,15 +20,13 @@ Progression of the minimum requirements page design:
     {
       text: "Question 1: Candidates with pending GCSEs",
       img: {
-        path: "/images/publish-teacher-training-courses/new-course-wizard-iteration-9-apr",
-        src: "candidates-with-pending-gcses.png"
+        src: "/publish-teacher-training-courses/new-course-wizard-iteration-9-apr/candidates-with-pending-gcses.png"
       }
     },
     {
       text: "Question 2: Tests for candidates without GCSE requirements",
       img: {
-        path: "/images/publish-teacher-training-courses/new-course-wizard-iteration-9-apr",
-        src: "tests-for-candidates-without-gcse-requirements.png"
+        src: "/publish-teacher-training-courses/new-course-wizard-iteration-9-apr/tests-for-candidates-without-gcse-requirements.png"
       }
     },
     { text: "Two questions" },
@@ -38,15 +36,13 @@ Progression of the minimum requirements page design:
     {
       text: "Introduce options",
       img: {
-        path: "/images/publish-teacher-training-courses/new-course-iteration",
-        src: "minimum-gcse-requirements.png"
+        src: "/publish-teacher-training-courses/new-course-iteration/minimum-gcse-requirements.png"
       }
     },
     {
       text: "Original design",
       img: {
-        path: "/images/publish-teacher-training-courses/minimum-requirements",
-        src: "minimum-course-requirements.png"
+        src: "/publish-teacher-training-courses/minimum-requirements/minimum-course-requirements.png"
       }
     }
   ]

--- a/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-16-minimum-course-requirements-logic.md
@@ -41,9 +41,15 @@ A user can select Yes to equivalency tests but can restrict this by subject (see
 
 {% from "screenshots/macro.njk" import appScreenshots with context %}
 {{ appScreenshots({
-  path: "/images/publish-teacher-training-courses/new-course-wizard-iteration-9-apr",
-  items: [
-    { text: "Question 1", id: "candidates-with-pending-gcses" },
-    { text: "Question 2", id: "tests-for-candidates-without-gcse-requirements" }
-  ]
+  items: [{
+    text: "Question 1",
+    img: {
+      src: "/publish-teacher-training-courses/new-course-wizard-iteration-9-apr/candidates-with-pending-gcses.png"
+    }
+  }, {
+    text: "Question 2",
+    img: {
+      src: "/publish-teacher-training-courses/new-course-wizard-iteration-9-apr/tests-for-candidates-without-gcse-requirements.png"
+    }
+  }]
 }) }}

--- a/app/posts/publish-teacher-training-courses/2020-02-15-new-course-wizard-available.md
+++ b/app/posts/publish-teacher-training-courses/2020-02-15-new-course-wizard-available.md
@@ -1,6 +1,6 @@
 ---
 title: New course wizard as launched for accredited bodies
-description: The new course wizard is now available to accredited bodies.  
+description: The new course wizard is now available to accredited bodies.
 date: 2020-02-15
 ---
 Development of the new course wizard began in September 2019 and was made available to accredited bodies in mid-February 2020.
@@ -11,15 +11,15 @@ Accredited bodies are able to access the new course wizard from the [Courses pag
 
 ## Why the wizard is not yet available to school directs
 
-School directs will not receive access to the new course wizard until Publish can automatically notify their accredited body that a course has been created. 
+School directs will not receive access to the new course wizard until Publish can automatically notify their accredited body that a course has been created.
 
-An accredited body needs to be notified immediately so they can maintain accurate data in their record systems. This was highlighted in [Accredited bodies research - Reporting round 2](publish-teacher-training-courses/accredited-bodies-research-round-2).
- 
+An accredited body needs to be notified immediately so they can maintain accurate data in their record systems. This was highlighted in [Accredited bodies research - Reporting round 2](/publish-teacher-training-courses/accredited-bodies-research-round-2).
+
 Publish will shortly [provide these notifications](https://bat-design-history.netlify.com/publish-teacher-training-courses/notifications-mvp) to ensure this need is met. Once notifications are enabled all users will have access to the wizard.
 
 ## Course creation for school directs
 
-All school direct users are required to [submit a google form](/publish-teacher-training-courses/new-course-google-form) to request a new course. 
+All school direct users are required to [submit a google form](/publish-teacher-training-courses/new-course-google-form) to request a new course.
 
 After receiving the request, DfE support creates the course manually and notifies both the school direct and associated accredited body via email of the new course’s availability.
 
@@ -64,7 +64,7 @@ Access the course wizard by appending `/new` to an organisations course page URL
     },
     {
       text: "When will applications open"
-    }, 
+    },
     {
       text: "When does the course start"
     },

--- a/app/posts/publish-teacher-training-courses/2020-10-01-uncoupling-UK-and-EU-course-fees.md
+++ b/app/posts/publish-teacher-training-courses/2020-10-01-uncoupling-UK-and-EU-course-fees.md
@@ -23,8 +23,7 @@ Publish previously allowed organisations to provide a common fee for UK and EU s
 {% from "figure/macro.njk" import appFigure with context %}
 {{ appFigure({
   image: {
-    path: "/images/publish-teacher-training-courses/uncoupling-UK-and-EU-course-fees/",
-    file: "original-edit-course-fees.png",
+    file: "/publish-teacher-training-courses/uncoupling-UK-and-EU-course-fees/original-edit-course-fees.png",
     alt: "Screenshot the original edit course length and fees page."
   }
 }) }}

--- a/app/posts/register-trainee-teachers/2020-11-27-beta-prototype-research-round-3.md
+++ b/app/posts/register-trainee-teachers/2020-11-27-beta-prototype-research-round-3.md
@@ -8,7 +8,7 @@ related:
     href: https://lookback.io/org/dfe-digital/projects/register-i-round-3-i-ao-provider-led/rounds
   - text: Raw findings
     href: https://drive.google.com/drive/u/0/folders/19Ir3HwBuwOVg50cFm3dDi2-EfQ1ZmY4I
-  - text: Research Plan 
+  - text: Research Plan
     href: https://docs.google.com/document/d/1bppLVBhXxf-rOSR6GVzIXx1Oifgc9wdr2BrjmNKerqI/
   - text: Research playback
     href: https://docs.google.com/presentation/d/1t5uAjPsI_Y6cnHO9o5__XFfQeMzdX9o54Gz1Yy7a3Ew/
@@ -28,7 +28,7 @@ Since UR round 2 we made some key changes to the prototype:
 
 The intention was to answer the following questions:
 
-* how do users that are responsible for multiple providers (e.g. lead schools) manage data? 
+* how do users that are responsible for multiple providers (e.g. lead schools) manage data?
 * what are the habits and needs around early data input and submitting for TRN (prior to course start)
 * how do providers refer to their courses and how familiar are they with the Publish course codes?
 * do users understand our review and confirm features, as well as our error messages?
@@ -73,17 +73,17 @@ So far there is no interest in submitting for TRN early, before trainees have st
 
 Users did respond positively to the possibility of creating drafts as soon as they have the data - throughout the year. Yet despite this most also said they would still prefer to upload all the data in one go in September.
 
->“I don’t work over July / August. I [...] start uploading when I get the opportunity in September. 
+>“I don’t work over July / August. I [...] start uploading when I get the opportunity in September.
 >
->If I managed to move the way we work back [and] had more time in July then I might [input data earlier]. If we’re still interviewing, we would end up with part-done, part-not-done [records], it would get a bit disjointed. 
+>If I managed to move the way we work back [and] had more time in July then I might [input data earlier]. If we’re still interviewing, we would end up with part-done, part-not-done [records], it would get a bit disjointed.
 >
 >To do that in July would take me away from other stuff, but it might be helpful.”
 
-Our system currently supports creating drafts and submitting records for individual trainees. If we were to enable submitting a group of draft records in one go, we may need to rethink [how we display drafts](/images/register-trainee-teachers/beta-prototype-updates/2020.11.02_12_29_04_Trainee%20teachers%20-%20Register%20trainee%20teachers%20-%20GOV.UK.png) in the user interface. 
+Our system currently supports creating drafts and submitting records for individual trainees. If we were to enable submitting a group of draft records in one go, we may need to rethink [how we display drafts](/register-trainee-teachers/beta-prototype-updates/2020.11.02_12_29_04_Trainee%20teachers%20-%20Register%20trainee%20teachers%20-%20GOV.UK.png) in the user interface.
 
 ### Homepage
 
-The homepage seems to work well as a springboard into our service. Users understand the statuses and appreciate them as shortcuts to the filtered records. Users understand what cycle the information relates to. 
+The homepage seems to work well as a springboard into our service. Users understand the statuses and appreciate them as shortcuts to the filtered records. Users understand what cycle the information relates to.
 
 >“That’s really good because a lot of the time [in DTTP] there’s no clear indication of how many I’m waiting for. This is really clear what the status of everything is.”
 
@@ -104,7 +104,7 @@ Pulling data through from Publish is a good solution for programme data input. T
 
 >“Useful that this has already been populated - I assume it comes through Publish?”
 
-Subject and course code seemed to be the most important details needed to identify a course. We [adjusted the prototype](/images/register-trainee-teachers/picking-publish-courses/asking-for-publish-course.png) to respond to this feedback during the testing round - removing data that did not help users identify a course. 
+Subject and course code seemed to be the most important details needed to identify a course. We [adjusted the prototype](/register-trainee-teachers/picking-publish-courses/asking-for-publish-course.png) to respond to this feedback during the testing round - removing data that did not help users identify a course.
 
 The current design works well for picking from around 10 courses or less - but we have providers that offer up to 90 courses, and we need to make sure our solution works for them too.
 
@@ -112,13 +112,13 @@ The current design works well for picking from around 10 courses or less - but w
 
 ### Confirming data input and error messages
 
-Users liked the idea of checking their work using the section confirmation pages  and understood the progress labels. 
+Users liked the idea of checking their work using the section confirmation pages  and understood the progress labels.
 
 > "The ‘Completed’ button says ‘I’m happy with this section‘, and that this is ok to be saved against that record."
 
 > "There could be certain sections where I’d want to save a partially complete record. [It should then show] in progress or draft."
 
-Users also understood different error messages and were able to adjust data to submit easily.     
+Users also understood different error messages and were able to adjust data to submit easily.
 
 ### Negative assessment outcome
 
@@ -146,8 +146,8 @@ Users act responsibly when it comes to updating outcomes on DTTP, but because an
 
 Lookback highlights:
 
-[What happens if a trainee fails?](https://lookback.io/watch/Hqxvr2mhA37qBnTJ5 ) 
-[When do you make this decision?](https://lookback.io/watch/2Top4tRiz4MJwpM3u) 
+[What happens if a trainee fails?](https://lookback.io/watch/Hqxvr2mhA37qBnTJ5 )
+[When do you make this decision?](https://lookback.io/watch/2Top4tRiz4MJwpM3u)
 
 ### Handling ITT data for several organisations
 


### PR DESCRIPTION
In preparation for simplifying figures and screenshots (see #403), update where we serve images from:

* When generating the site, copy files from the `images` folder, and save alongside post HTML. This means that, in most cases, we can continue to only call an image’s filename, but without needing to do any workarounds in the different components to get the right path
* Remove `appImage` component.
  * When used in Markdown files, use Markdown image syntax instead
  * When used in `appFigure` component, use HTML instead
* Remove `path` param on `appFigure` component, provide full path if necessary in `file` param (the `appFigure` component will be removed in a later PR)
* Update places where we reference images being in the `images` folder to point to new image locations