### PR TITLE
Auto linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,5 +13,14 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install packages
       run: npm install
-    - name: Run linters
+    - name: Run linters with autofix
+      run: npm run lint:fix
+    - name: Push any fixes
+      run: |
+        git config --global user.email "lint-bot@example.com"
+        git config --global user.name "lint-bot"
+        git add --all
+        git commit -m "Code style fixes" || exit 0
+        git push
+    - name: Re-run linters
       run: npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,16 +1,14 @@
 name: Lint
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [pull_request]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
     - name: Install packages
       run: npm install
     - name: Run linters with autofix

--- a/app/_javascripts/application.js
+++ b/app/_javascripts/application.js
@@ -4,6 +4,6 @@ const $searchContainer = document.querySelector('[data-module="app-search"]')
 new Search($searchContainer).init()
 
 window.onload = function () {
-  document.documentElement.classList.remove('no-js');
+  document.documentElement.classList.remove('no-js')
   window.GOVUKFrontend.initAll()
 }

--- a/app/_javascripts/application.js
+++ b/app/_javascripts/application.js
@@ -4,6 +4,6 @@ const $searchContainer = document.querySelector('[data-module="app-search"]')
 new Search($searchContainer).init()
 
 window.onload = function () {
-  document.documentElement.classList.remove('no-js')
+  document.documentElement.classList.remove('no-js');
   window.GOVUKFrontend.initAll()
 }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,11 @@
     "start": "npm run watch:files",
     "dev": "npm run watch",
     "lint:javascripts": "standard",
+    "lint:javascripts:fix": "standard --fix",
     "lint:markdown": "markdownlint 'app/**/*.md'",
-    "lint": "npm-run-all lint:*"
+    "lint:markdown:fix": "markdownlint 'app/**/*.md' --fix",
+    "lint": "npm-run-all lint:javascripts lint:markdown",
+    "lint:fix": "npm-run-all lint:javascripts:fix lint:markdown:fix"
   },
   "dependencies": {
     "@11ty/eleventy": "^0.12.1",


### PR DESCRIPTION
We have a "linter" task set up which checks for some minor code style things in the javascript and markdown files. Both of those tools have an "auto-fix" mode, which attempts to automatically fix as many things as possible (some require human intervention).

This PR lets you easily run them both in that mode by running:

```bash
npm run lint:fix
```

In addition, for any Pull Requests opened on GitHub, GitHub will run the linters in that mode, and then will push any fixes. It will still alert you if there are any remaining issues which couldn’t be fixed automatically.