### PR TITLE
Add mission patch for Apply UCAS Switch-off

### DIFF
--- a/app/mission-patches.md
+++ b/app/mission-patches.md
@@ -86,7 +86,7 @@ The team was formed during a period where they couldn’t be physically near, so
     caption: "This patch celebrated how well the team handled the allocations request period. It was a stressful time but we remained calm and collected. July 2020"
   }, {
     text: "Data discovery",
-    caption: "This patch celebrated the completion of a discovery into the department’s data collection and usage. The team chose a lobster (named Madame Michelle Bisque) as they uncovered many legacy systems which like lobsters, [tend to live far longer than they should](https://twitter.com/drsnooks/status/1217775748980912130). February 2020"
+    caption: "This patch celebrated the completion of a discovery into the department’s data collection and usage. The team chose a lobster (named Madame Michelle Bisque) as they uncovered many legacy systems which like lobsters, [tend to live far longer than they should](https://twitter.com/drsnooks/status/1217775748980912130). February 2020" | markdown | safe
   }, {
     text: "Impact squad",
     caption: "This patch celebrated the creation of a team to coordinate impactful change across the service line. The team chose an elephant (named Kahar after the team’s founding product manager) given their strength, wisdom and memory. Different coloured eyes represent diversity, and that the team works across Get into teaching (green) and Becoming a teacher (blue). May 2021"

--- a/app/mission-patches.md
+++ b/app/mission-patches.md
@@ -33,6 +33,9 @@ The mascot for Apply (and Manage) is a beaver named Brian Townley. We chose a be
   }, {
     text: "Apply for teacher training HEI Pilot",
     caption: "This patch celebrated 11 early-adopter HEIs joining Apply as we embarked on our second recruitment cycle. As the University of Bedfordshire was the first HEI to be onboarded, Brian’s mortarboard featured a red tassel. October 2020"
+  }, {
+    text: "Apply for teacher training UCAS Switch-off",
+    caption: "This patch celebrated applications for the 2022/23 cycle being made exclusively via the Apply service. Brian dons the helmet he wore in his very first patch as he detonates the UCAS ITT service he helped to replace. October 2021"
   }]
 }) }}
 


### PR DESCRIPTION
…and fix the non-rendered Markdown link in the caption for the Data Discovery patch.