### PR TITLE
Make website indexable in search engines like Google

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -11,7 +11,6 @@
 <meta property="og:title" content="{{ title }}">
 {% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
 <meta property="og:image" content="/opengraph-image.png">
-<meta name="robots" content="noindex nofollow">
 {% endblock %}
 
 {% block pageTitle %}

--- a/app/robots.njk
+++ b/app/robots.njk
@@ -1,6 +1,0 @@
----
-eleventyExcludeFromCollections: true
-permalink: /robots.txt
----
-User-agent: *
-Disallow: /

--- a/app/robots.njk
+++ b/app/robots.njk
@@ -1,0 +1,6 @@
+---
+eleventyExcludeFromCollections: true
+permalink: /robots.txt
+---
+User-agent: *
+Allow: /


### PR DESCRIPTION
It's difficult to find posts in the design history using the autocomplete search alone.

Enabling the site to be spidered will let users find things via Google, for example.

It'll also let us add a Google search form to the site if we choose to do that later.