### PR TITLE
Add/update meta description

### DIFF
--- a/app/_data/app.js
+++ b/app/_data/app.js
@@ -1,5 +1,6 @@
 module.exports = {
   productName: 'Becoming a teacher design history',
+  description: 'A history of the designs for the Find, Apply, Publish, Manage, Register and Support services',
   sections: {
     title: 'Services'
   }

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -8,8 +8,9 @@
 {% block head %}
 <!--[if lte IE 8]><link href="/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
+<meta name="description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Apply, Find, Publish and Register services') }}">
 <meta property="og:title" content="{{ title }}">
-{% if description %}<meta property="og:description" name="description" content="{{ description | markdown("inline") | striptags(true) }}">{% endif %}
+<meta property="og:description" name="description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Apply, Find, Publish and Register services') }}">
 <meta property="og:image" content="/opengraph-image.png">
 {% endblock %}
 

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -10,7 +10,7 @@
 <!--[if gt IE 8]><!--><link href="/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
 <meta name="description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Apply, Find, Publish and Register services') }}">
 <meta property="og:title" content="{{ title }}">
-<meta property="og:description" name="description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Apply, Find, Publish and Register services') }}">
+<meta property="og:description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Apply, Find, Publish and Register services') }}">
 <meta property="og:image" content="/opengraph-image.png">
 {% endblock %}
 

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -8,9 +8,9 @@
 {% block head %}
 <!--[if lte IE 8]><link href="/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
-<meta name="description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Find, Apply, Publish, Manage, Register and Support services') }}">
+<meta name="description" content="{{ description | markdown('inline') | striptags(true) | default(app.description) }}">
 <meta property="og:title" content="{{ title }}">
-<meta property="og:description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Find, Apply, Publish, Manage, Register and Support services') }}">
+<meta property="og:description" content="{{ description | markdown('inline') | striptags(true) | default(app.description) }}">
 <meta property="og:image" content="/opengraph-image.png">
 {% endblock %}
 

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -8,9 +8,9 @@
 {% block head %}
 <!--[if lte IE 8]><link href="/stylesheets/application-ie8.css" rel="stylesheet" type="text/css" /><![endif]-->
 <!--[if gt IE 8]><!--><link href="/stylesheets/application.css" media="all" rel="stylesheet" type="text/css" /><!--<![endif]-->
-<meta name="description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Apply, Find, Publish and Register services') }}">
+<meta name="description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Find, Apply, Publish, Manage, Register and Support services') }}">
 <meta property="og:title" content="{{ title }}">
-<meta property="og:description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Apply, Find, Publish and Register services') }}">
+<meta property="og:description" content="{{ description | markdown('inline') | striptags(true) | default('A history of the designs for the Find, Apply, Publish, Manage, Register and Support services') }}">
 <meta property="og:image" content="/opengraph-image.png">
 {% endblock %}
 


### PR DESCRIPTION
We have now opened the design history site to search engines.

The meta description for the site is missing, which means search engines display "no information is available for this page".

![image](https://user-images.githubusercontent.com/23444/140378372-2a430fd9-36e2-4edf-af02-8246d9a26f4b.png)

What we've done:

- Added a meta description tag
- Updated the meta `og:description` tag to default to the site's description if none present