### PR TITLE
Remove "– GOV.UK " from page title

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {% if title %}{{ title }} - {% endif %}{{ app.serviceName or app.productName }} - GOV.UK
+  {% if title %}{{ title }} - {% endif %}{{ app.serviceName or app.productName }}
 {% endblock %}
 
 {% block header %}

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block pageTitle %}
-  {% if title %}{{ title }} - {% endif %}{{ app.serviceName or app.productName }}
+  {% if title %}{{ title }} - {% endif %}{{ app.serviceName or app.productName }} - Department for Education
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
Should probably remove this, as the site isn't part of GOV.UK?