### PR TITLE
Update landing page description and service order

### DIFF
--- a/app/index.md
+++ b/app/index.md
@@ -1,7 +1,7 @@
 ---
 layout: collection
 title: Becoming a teacher design history
-description: A history of the designs for the Apply, Find, Publish and Register services
+description: A history of the designs for the Find, Apply, Publish, Manage, Register and Support services
 eleventyComputed:
   eleventyNavigation:
     key: home

--- a/app/posts/apply-for-teacher-training/apply-for-teacher-training.md
+++ b/app/posts/apply-for-teacher-training/apply-for-teacher-training.md
@@ -23,5 +23,5 @@ eleventyComputed:
     key: "{{ title }}"
     excerpt: "{{ description }}"
     parent: home
-    order: 3
+    order: 2
 ---

--- a/app/posts/publish-teacher-training-courses/publish-teacher-training-courses.md
+++ b/app/posts/publish-teacher-training-courses/publish-teacher-training-courses.md
@@ -23,5 +23,5 @@ eleventyComputed:
     key: "{{ title }}"
     excerpt: "{{ description }}"
     parent: home
-    order: 2
+    order: 3
 ---

--- a/app/posts/register-trainee-teachers/register-trainee-teachers.md
+++ b/app/posts/register-trainee-teachers/register-trainee-teachers.md
@@ -21,5 +21,5 @@ eleventyComputed:
     key: "{{ title }}"
     excerpt: "{{ description }}"
     parent: home
-    order: 6
+    order: 5
 ---

--- a/app/posts/support-for-apply/support-for-apply.md
+++ b/app/posts/support-for-apply/support-for-apply.md
@@ -23,5 +23,5 @@ eleventyComputed:
     key: "{{ title }}"
     excerpt: "{{ description }}"
     parent: home
-    order: 5
+    order: 6
 ---


### PR DESCRIPTION
What's changed:

- Included `Manage` and `Support` services in the landing page description
- Matched the order of the listed services with the page description