### PR TITLE
Update glossary to remove definition list

### DIFF
--- a/app/glossary.md
+++ b/app/glossary.md
@@ -145,7 +145,7 @@ The commonly used name of an educational organisation. This may not be the legal
 
 This term is sometimes used to differentiate the teaching of languages in everyday use from ‘ancient languages’ such as Latin and Ancient Greek which are no longer widely spoken. It also typically does not include teaching English. Prefer listing the specific languages where possible.
 
-### Multi-Academy Trust (MAT)
+### Multi-academy trust (MAT)
 
 A single trust responsible for a group of academies. MATs can be providers but cannot be lead schools.
 
@@ -175,18 +175,21 @@ This is a teaching qualification that - when it’s paired with QTS (qualified t
 
 Very similar to the PGCE. Generally includes more credits towards a Master’s degree.
 
-Provider led
-: A course that that is led by an HEI or a SCITT (the opposite of school led/based).
+### Provider led
+
+A course that that is led by an HEI or a SCITT (the opposite of school led/based).
 
 ## Q
 
-Qualified teacher status (QTS)
-: This is the qualification you need to teach in state schools in England. You can’t teach without it.
+### Qualified teacher status (QTS)
+
+This is the qualification you need to teach in state schools in England. You can’t teach without it.
 
 ## R
 
-Rollover
-: This takes place in Publish - it’s the copying over of courses from one recruitment cycle to the next. It starts in mid July and takes about a month in full. All courses are copied over; training providers can then eliminate any courses they don’t want to run, and make any other changes to ensure their course profiles are correct for the upcoming cycle.
+### Rollover
+
+This takes place in Publish - it’s the copying over of courses from one recruitment cycle to the next. It starts in mid July and takes about a month in full. All courses are copied over; training providers can then eliminate any courses they don’t want to run, and make any other changes to ensure their course profiles are correct for the upcoming cycle.
 
 ## S
 
@@ -194,7 +197,7 @@ Rollover
 
 See [Bursaries](#bursaries-and-scholarships).
 
-### School Centred Initial Teacher Training (SCITT)
+### School centred initial teacher training (SCITT)
 
 School-centred initial teacher training provider. A SCITT is most commonly a school who have incorporated a separate legal entity (company) dedicated to delivering teacher training. SCITTs are accredited bodies.
 

--- a/app/glossary.md
+++ b/app/glossary.md
@@ -15,130 +15,165 @@ A collection of terms commonly used across the Becoming a Teacher service lines.
 
 ## A
 
-Accreditation
-: All initial teacher training providers must be ‘accredited’ by the Secretary of State for Education. This process of ‘accreditation’ confirms they have permission to offer courses leading to Qualified Teacher Status (QTS). (NB: Ofsted is the body which checks the courses providers offer meet the standards set by the department.)
-: The exception is the School Direct (SD) training route; SDs need a ‘ratifying accredited provider’. The ratifying accredited provider may be a School Centred Initial Teacher Training (SCITT) or a Higher Education Institute (HEI), and is responsible for maintaining the quality of the training provided.
-: As accredited bodies, SCITTs can offer QTS courses but do not have the power to award a degree. To enable candidates who seek an academic award like a PGCE (Post Graduate Certificate in Education) they need to partner with an HEI.
-: The relationship between accredited training providers and the institutions they ratify is complex. For example, we know that individual courses can be ratified by different accredited bodies (so a School Direct may work with both an HEI and more than one SCITT to ratify its courses).
+### Accreditation
 
-Allocation
-: Permission to run limited courses.
+All initial teacher training providers must be ‘accredited’ by the Secretary of State for Education. This process of ‘accreditation’ confirms they have permission to offer courses leading to Qualified Teacher Status (QTS). (NB: Ofsted is the body which checks the courses providers offer meet the standards set by the department.)
 
-Ancient languages
-: Used to describe teaching the study of languages no longer in widespread spoken usage, such as Latin or Ancient Greek. Prefer using the specific languages studied where possible.
+The exception is the School Direct (SD) training route; SDs need a ‘ratifying accredited provider’. The ratifying accredited provider may be a School Centred Initial Teacher Training (SCITT) or a Higher Education Institute (HEI), and is responsible for maintaining the quality of the training provided.
+
+As accredited bodies, SCITTs can offer QTS courses but do not have the power to award a degree. To enable candidates who seek an academic award like a PGCE (Post Graduate Certificate in Education) they need to partner with an HEI.
+
+The relationship between accredited training providers and the institutions they ratify is complex. For example, we know that individual courses can be ratified by different accredited bodies (so a School Direct may work with both an HEI and more than one SCITT to ratify its courses).
+
+### Allocation
+
+Permission to run limited courses.
+
+### Ancient languages
+
+Used to describe teaching the study of languages no longer in widespread spoken usage, such as Latin or Ancient Greek. Prefer using the specific languages studied where possible.
 
 ## B
 
-Becoming a teacher (BAT)
-: Our service line.
+### Becoming a teacher (BAT)
 
-Bursaries AND Scholarships
-: These are sums of money available to trainees on (fee-based) courses in certain subjects. They’re tax-free, and awarded by DfE, in some cases in partnership with professional bodies. The main difference between bursaries and scholarships is that the value of scholarships is a little higher, and you’ll generally need a 2:1 to qualify for one (you’ll only need a 2:2 to get a bursary). You also have to apply for a scholarship, whereas you’ll automatically receive a bursary once you start training (if you meet the criteria). You can only claim one of them - not both.
+Our service line.
+
+### Bursaries AND Scholarships
+
+These are sums of money available to trainees on (fee-based) courses in certain subjects. They’re tax-free, and awarded by DfE, in some cases in partnership with professional bodies. The main difference between bursaries and scholarships is that the value of scholarships is a little higher, and you’ll generally need a 2:1 to qualify for one (you’ll only need a 2:2 to get a bursary). You also have to apply for a scholarship, whereas you’ll automatically receive a bursary once you start training (if you meet the criteria). You can only claim one of them - not both.
 
 ## C
 
-Course
-: A training programme providers create for candidates to apply to.
+### Course
 
-Course Code
-: A code used to identify courses (unique to a provider).
+A training programme providers create for candidates to apply to.
 
-Cycle
-: The period during which ITT applications are open, usually beginning in October and ending in September.
+### Course Code
+
+A code used to identify courses (unique to a provider).
+
+### Cycle
+
+The period during which ITT applications are open, usually beginning in October and ending in September.
 
 ## D
 
-Database of Qualified Teachers (DQT)
-: A database maintained by the Teacher Regulation Agency. Teachers can sign in to view their teacher record, get copies of QTS and other teaching related qualifications and update their personal and employment details.
+### Database of Qualified Teachers (DQT)
 
-DBS check
-: A service from the Disclosure and Barring Service which checks for any potential criminal record. There are four levels, ‘basic’, ‘standard’, ‘enhanced’ and ‘enhanced with barred lists’. Applying for teacher training requires the enhanced check. Generally, the acronym does not need to be spelled out, but the check should be described, for example as a criminal record check. See [DBS checks](https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks).
+A database maintained by the Teacher Regulation Agency. Teachers can sign in to view their teacher record, get copies of QTS and other teaching related qualifications and update their personal and employment details.
 
-DTTP
-: [Database of trainee teachers and providers](https://www.gov.uk/guidance/database-of-trainee-teachers-and-providers-dttp).
+### Disclosure and Barring Service (DBS) check
+
+A service from the Disclosure and Barring Service which checks for any potential criminal record. There are four levels, ‘basic’, ‘standard’, ‘enhanced’ and ‘enhanced with barred lists’. Applying for teacher training requires the enhanced check. Generally, the acronym does not need to be spelled out, but the check should be described, for example as a criminal record check. See [DBS checks](https://www.gov.uk/government/organisations/disclosure-and-barring-service/about#dbs-checks).
+
+### Database of trainee teachers and providers (DTTP)
+
+[Database of trainee teachers and providers](https://www.gov.uk/guidance/database-of-trainee-teachers-and-providers-dttp).
 
 ## E
 
-Early career payments
-: These apply to chemistry, languages, maths and physics. They’re sums of money you get after you’ve qualified as a teacher - they’re paid out in your second, third and fourth year of teaching. You get £2k each year - £3k in some parts of the country.
+### Early career payments
 
-English Baccalaureate (EBacc)
-: A combination of subjects (the ‘core’ subjects, academically) that pupils can study at GCSE level. The EBacc is not a qualification in itself. The government assesses school performance based on how well pupils perform in the EBacc subjects. It’s also used as something of a marketing device - pupils are encouraged to choose these subjects.
+These apply to chemistry, languages, maths and physics. They’re sums of money you get after you’ve qualified as a teacher - they’re paid out in your second, third and fourth year of teaching. You get £2k each year - £3k in some parts of the country.
 
-English as a foreign language
-: Used to describe the use of English by people whose first language or languages are not English. The teaching of this is a specialism sometimes described as ‘teaching English as a foreign language’ (TEFL). The use of English as a foreign language can be assessed through formal assessments such the ‘International English Language Testing System’ (IELTS) and ‘Test of English as a Foreign Language’ (TOEFL).
+### English Baccalaureate (EBacc)
 
-Early years initial teacher training (EYITT)
-: The equivalent to ITT but specifically for teaching 0 to 5 year olds.
+A combination of subjects (the ‘core’ subjects, academically) that pupils can study at GCSE level. The EBacc is not a qualification in itself. The government assesses school performance based on how well pupils perform in the EBacc subjects. It’s also used as something of a marketing device - pupils are encouraged to choose these subjects.
 
-Early years teacher status (EYTS)
-: The equivalent to QTS and allows you to teach 0 to 5 year olds.
+### English as a foreign language
+
+Used to describe the use of English by people whose first language or languages are not English. The teaching of this is a specialism sometimes described as ‘teaching English as a foreign language’ (TEFL). The use of English as a foreign language can be assessed through formal assessments such the ‘International English Language Testing System’ (IELTS) and ‘Test of English as a Foreign Language’ (TOEFL).
+
+### Early years initial teacher training (EYITT)
+
+The equivalent to ITT but specifically for teaching 0 to 5 year olds.
+
+### Early years teacher status (EYTS)
+
+The equivalent to QTS and allows you to teach 0 to 5 year olds.
 
 ## F
 
-Fitness to teach check
-: This is not a specific check, but a general description of assessments of a person’s health and physical and mental capacity to teach. Each provider may use different processes or services for these checks, which are usually a condition of offers on teacher training courses.
+### Fitness to teach check
 
-Further Education
-: This is an educational level between secondary and higher education. It tends to be vocational. Most people studying FE courses will be over 16, but some courses are available to people aged 14 and over. FE courses are usually taught in FE colleges, sixth form colleges, and adult education centres (ie not schools). Strictly speaking, A Levels are part of FD - however, the term is generally used to refer to non-academic, vocational/skills-focused training.
+This is not a specific check, but a general description of assessments of a person’s health and physical and mental capacity to teach. Each provider may use different processes or services for these checks, which are usually a condition of offers on teacher training courses.
+
+### Further Education
+
+This is an educational level between secondary and higher education. It tends to be vocational. Most people studying FE courses will be over 16, but some courses are available to people aged 14 and over. FE courses are usually taught in FE colleges, sixth form colleges, and adult education centres (ie not schools). Strictly speaking, A Levels are part of FD - however, the term is generally used to refer to non-academic, vocational/skills-focused training.
 
 ## G
 
-Get information about schools (GIAS)
-: This is a [register of schools and colleges in England](https://get-information-schools.service.gov.uk/).
+### Get information about schools (GIAS)
 
-Get Into Teaching (GIT)
-: A marketing campaign and website to encourage people to become a teacher. The brand is capitalised, and the acronym should not be used publicly. See [Get Into Teaching](https://getintoteaching.education.gov.uk) website.
+This is a [register of schools and colleges in England](https://get-information-schools.service.gov.uk/).
+
+### Get Into Teaching (GIT)
+
+A marketing campaign and website to encourage people to become a teacher. The brand is capitalised, and the acronym should not be used publicly. See [Get Into Teaching](https://getintoteaching.education.gov.uk) website.
 
 ## H
 
-HESA
-: The [Higher Education Statistics Agency](https://www.hesa.ac.uk) is the official agency for the collection, analysis and dissemination of quantitative information about higher education in the United Kingdom.
+### Higher Education Statistics Agency (HESA)
 
-Higher education institution (HEI)
-: A university.
+The [Higher Education Statistics Agency](https://www.hesa.ac.uk) is the official agency for the collection, analysis and dissemination of quantitative information about higher education in the United Kingdom.
+
+### Higher education institution (HEI)
+
+A university.
 
 ## I
 
-Initial teacher training (ITT)
-: The training you have to do to become a teacher. It’s usually fine to say ’teacher training’ rather than ’initial teacher training’. The ’ITT’ abbreviation should be avoided - instead say teacher training, or just training.
+### Initial teacher training (ITT)
+
+The training you have to do to become a teacher. It’s usually fine to say ’teacher training’ rather than ’initial teacher training’. The ’ITT’ abbreviation should be avoided - instead say teacher training, or just training.
 
 ## L
 
-Lead school
-: The main organisation in a School Direct partnership. It can be a maintained school, academy, head office, sixth form college, pupil referral unit, or free school. It partners with other schools and accredited bodies to deliver teacher training courses. It has overall responsibility for making sure that School Direct criteria are upheld, and for requesting training places from DfE. Places are allocated directly to the lead school. A ’good’ or ’outstanding’ Ofsted rating is a requirement for lead schools.
+### Lead school
+
+The main organisation in a School Direct partnership. It can be a maintained school, academy, head office, sixth form college, pupil referral unit, or free school. It partners with other schools and accredited bodies to deliver teacher training courses. It has overall responsibility for making sure that School Direct criteria are upheld, and for requesting training places from DfE. Places are allocated directly to the lead school. A ’good’ or ’outstanding’ Ofsted rating is a requirement for lead schools.
 
 ## M
 
-Marketing name
-: The commonly used name of an educational organisation. This may not be the legal name.
+### Marketing name
 
-Modern languages
-: This term is sometimes used to differentiate the teaching of languages in everyday use from ‘ancient languages’ such as Latin and Ancient Greek which are no longer widely spoken. It also typically does not include teaching English. Prefer listing the specific languages where possible.
+The commonly used name of an educational organisation. This may not be the legal name.
 
-Multi-Academy Trust (MAT)
-: A single trust responsible for a group of academies. MATs can be providers but cannot be lead schools.
+### Modern languages
+
+This term is sometimes used to differentiate the teaching of languages in everyday use from ‘ancient languages’ such as Latin and Ancient Greek which are no longer widely spoken. It also typically does not include teaching English. Prefer listing the specific languages where possible.
+
+### Multi-Academy Trust (MAT)
+
+A single trust responsible for a group of academies. MATs can be providers but cannot be lead schools.
 
 ## N
 
-NASBTT
-: The [National Association of School-Based Teacher Trainers](https://www.nasbtt.org.uk) is a registered charity which represents the interests of schools-led teacher training provision in relation to the development and implementation of national policy developments. They are the largest representative body of SCITTs and School Directs.
+### National Association of School-Based Teacher Trainers (NASBTT)
 
-Niche routes
-: Non-mainstream routes into teaching, for example, Teach First.
+The [National Association of School-Based Teacher Trainers](https://www.nasbtt.org.uk) is a registered charity which represents the interests of schools-led teacher training provision in relation to the development and implementation of national policy developments. They are the largest representative body of SCITTs and School Directs.
+
+### Niche routes
+
+Non-mainstream routes into teaching, for example, Teach First.
 
 ## O
 
-Organisation
-: There’s no clear definition for this. We use it broadly to encompass the different types of entity involving in teacher training (schools, universities, School Directs, etc). So it’s a catch-all, umbrella term.
+### Organisation
+
+There’s no clear definition for this. We use it broadly to encompass the different types of entity involving in teacher training (schools, universities, School Directs, etc). So it’s a catch-all, umbrella term.
 
 ## P
 
-Postgraduate certificate in education (PGCE)
-: This is a teaching qualification that - when it’s paired with QTS (qualified teacher status) - allows you to teach in state schools in England, Scotland, Wales and Northern Ireland. It’s also recognised internationally (which is the major advantage of having it, over just QTS). PGCE without QTS qualifies you to teach further education, but not primary or secondary education.
+### Postgraduate certificate in education (PGCE)
 
-Postgraduate diploma in education (PGDE)
-: Very similar to the PGCE. Generally includes more credits towards a Master’s degree.
+This is a teaching qualification that - when it’s paired with QTS (qualified teacher status) - allows you to teach in state schools in England, Scotland, Wales and Northern Ireland. It’s also recognised internationally (which is the major advantage of having it, over just QTS). PGCE without QTS qualifies you to teach further education, but not primary or secondary education.
+
+### Postgraduate diploma in education (PGDE)
+
+Very similar to the PGCE. Generally includes more credits towards a Master’s degree.
 
 Provider led
 : A course that that is led by an HEI or a SCITT (the opposite of school led/based).
@@ -155,60 +190,78 @@ Rollover
 
 ## S
 
-Scholarships
-: See Bursaries.
+### Scholarships
 
-SCITT
-: School-centred initial teacher training provider. A SCITT is most commonly a school who have incorporated a separate legal entity (company) dedicated to delivering teacher training. SCITTs are accredited bodies.
+See [Bursaries](#bursaries-and-scholarships).
 
-School direct (SD)
-: Single school given school direct (fee and salaried) places. Must partner with an accredited body.
+### School Centred Initial Teacher Training (SCITT)
 
-Special educational needs and disability (SEND or SEN)
-: Needs and disabilities that can affect a child’s ability to learn. These children may be eligible for additional support. Both SEND and SEN acronyms are widely used, but the term should always be spelled out, uncapitalised, on initial use. See [Children with special education needs and disabilities (SEND)](https://www.gov.uk/children-with-special-educational-needs) on GOV.UK.
+School-centred initial teacher training provider. A SCITT is most commonly a school who have incorporated a separate legal entity (company) dedicated to delivering teacher training. SCITTs are accredited bodies.
 
-SITS
-: SITS:Vision, also known just as SITS, is a database application used for course and student management developed and maintained by the [Tribal Group](https://en.wikipedia.org/wiki/SITS:Vision). This is the most common student record system used by providers.
+### School direct (SD)
 
-Subject knowledge enhancement (SKE)
-: Subject knowledge enhancement courses are offered to enhance a candidates existing knowledge where they may not need a full course. See [Get Into Teaching’s page](https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses) for more details.
+Single school given school direct (fee and salaried) places. Must partner with an accredited body.
 
-Student record system (SRS)
-: Database application commonly used by further and higher education institutions to store, administer and manage all types of student information. Vendors of this software include Ellucian, Technology One, Tribal and Unit 4.
+### Special educational needs and disability (SEND or SEN)
+
+Needs and disabilities that can affect a child’s ability to learn. These children may be eligible for additional support. Both SEND and SEN acronyms are widely used, but the term should always be spelled out, uncapitalised, on initial use. See [Children with special education needs and disabilities (SEND)](https://www.gov.uk/children-with-special-educational-needs) on GOV.UK.
+
+### SITS
+
+SITS:Vision, also known just as SITS, is a database application used for course and student management developed and maintained by the [Tribal Group](https://en.wikipedia.org/wiki/SITS:Vision). This is the most common student record system used by providers.
+
+### Subject knowledge enhancement (SKE)
+
+Subject knowledge enhancement courses are offered to enhance a candidates existing knowledge where they may not need a full course. See [Get Into Teaching’s page](https://getintoteaching.education.gov.uk/explore-my-options/teacher-training-routes/subject-knowledge-enhancement-ske-courses) for more details.
+
+### Student record system (SRS)
+
+Database application commonly used by further and higher education institutions to store, administer and manage all types of student information. Vendors of this software include Ellucian, Technology One, Tribal and Unit 4.
 
 ## T
 
-Teacher Analysis Division (TAD)
-: Part of DfE.
+### Teacher Analysis Division (TAD)
 
-Teacher Qualifications Unit (TQU)
-: Administers the Database of Qualified Teachers.
+Part of DfE.
 
-Teacher Reference Number (TRN)
-: A unique number assigned to new teachers. The TRN follows teachers from training right through to pensions.
+### Teacher Qualifications Unit (TQU)
 
-Teacher Regulation Agency (TRA)
-: An executive agency of the DfE who maintains the database of qualified teachers in England, issues the TRN, awards QTS to teachers who complete ITT and awards EYTS to teachers who complete EYITT.
+Administers the Database of Qualified Teachers.
 
-Teacher supply model (TSM)
-: Used to predict and manage the ITT market.
+### Teacher Reference Number (TRN)
 
-Teaching School Alliance
-: Outstanding schools that work with others to provide high quality training to new and experienced staff. Cannot be lead schools or providers.
+A unique number assigned to new teachers. The TRN follows teachers from training right through to pensions.
+
+### Teacher Regulation Agency (TRA)
+
+An executive agency of the DfE who maintains the database of qualified teachers in England, issues the TRN, awards QTS to teachers who complete ITT and awards EYTS to teachers who complete EYITT.
+
+### Teacher supply model (TSM)
+
+Used to predict and manage the ITT market.
+
+### Teaching School Alliance
+
+Outstanding schools that work with others to provide high quality training to new and experienced staff. Cannot be lead schools or providers.
 
 ## U
 
-UCAS
-: The Universities and Colleges Admissions Service whose main role is to operate the application process for British universities.
+### UCAS
 
-UK ENIC
-: A service which provides impartial judgement on international qualifications, and how they compare to UK qualifications. Previously known as UK NARIC prior to the UK leaving the European Union. ENIC stands for European Network of Information Centres, but the term does not need to be spelled out. See [UK ENIC](https://www.enic.org.uk) website.
+The Universities and Colleges Admissions Service whose main role is to operate the application process for British universities.
 
-UK NARIC
-: Previous name for UK ENIC, whilst the UK was part of the EU.
+### UK ENIC
 
-UK Provider Reference Number (UKPRN)
-: This is the unique identifier given to higher education providers.
+A service which provides impartial judgement on international qualifications, and how they compare to UK qualifications. Previously known as UK NARIC prior to the UK leaving the European Union. ENIC stands for European Network of Information Centres, but the term does not need to be spelled out. See [UK ENIC](https://www.enic.org.uk) website.
 
-Unique Reference Number (URN)
-: This is the unique reference number given to all schools by Edubase.
+### UK NARIC
+
+Previous name for UK ENIC, whilst the UK was part of the EU.
+
+### UK Provider Reference Number (UKPRN)
+
+This is the unique identifier given to higher education providers.
+
+### Unique Reference Number (URN)
+
+This is the unique reference number given to all schools by Edubase.


### PR DESCRIPTION
We can't link to individual items in the glossary, only the individual letter headings.

This PR replaces the definition list with headings and paragraphs.