### PR TITLE
Allow checkout to work with forks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
     - name: Install packages
       run: npm install
     - name: Run linters with autofix


### PR DESCRIPTION
Currently the linter doesn’t work with pull requests raised from forks. I think removing this explicit ref should fix this, as the default [checkout action](https://github.com/actions/checkout) should work with forks as well as branches.