### PR TITLE
Fix markdown lint errors

### DIFF
--- a/app/posts/manage-teacher-training-applications/2020-05-18-access-control-history.md
+++ b/app/posts/manage-teacher-training-applications/2020-05-18-access-control-history.md
@@ -3,6 +3,7 @@ title: 'Setting user permissions: context and user research'
 description: Users and organisations need to configure permissions to make decisions, see safeguarding information and set controls for other users. Here's how we arrived at our designs
 date: 2020-05-18
 ---
+<!-- markdownlint-disable MD051 -->
 
 Teacher training providers have to partner with accredited bodies if they’re not an accredited body themselves. Accredited bodies maintain the quality of teacher training providers.
 
@@ -621,3 +622,5 @@ Note that for changing an offer in weblink, the user can change:
 [Return to table of contents](#table-of-contents)
 
 ---
+
+<!-- markdownlint-enable MD051 -->

--- a/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
+++ b/app/posts/publish-teacher-training-courses/2019-01-11-edit-course-information.md
@@ -1,6 +1,6 @@
 ---
 title: Course page – 11 January iteration
-description: Edit course information, update the status column.
+description: Edit course information, update the status column
 date: 2019-01-11
 screenshots:
   items:
@@ -13,6 +13,8 @@ screenshots:
     - Confirm answers (for comparison)
     - Organisation
 ---
+
+<!-- markdownlint-disable MD051 -->
 
 An iteration on the [current course page](/publish-teacher-training-courses/enrichment-sept-6#course) which:
 
@@ -51,3 +53,5 @@ The new design:
 * adds ‘Is it on Find?’, ‘Applications’ and ‘Vacancies’ labels to provide the same information as the course table
 * removes the ‘View on website’ section, replaced with ‘Is it on Find?’
 * moves the audit trail (eg when published, when saved) details to the bottom
+
+<!-- markdownlint-enable MD051 -->

--- a/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-19-edit-priorities.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: In what order should we build the Edit screens?
-description: List edit screens with their complexity and priority.
+description: List edit screens with their complexity and priority
 date: 2019-04-19
 screenshots:
   items:
@@ -22,6 +22,7 @@ screenshots:
     - Title
     - Confirm your changes
 ---
+<!-- markdownlint-disable MD051 -->
 
 [Edit screen workflows in a Google Drawing](https://docs.google.com/drawings/d/1OrJYSTmRSJD2GEAWFnr2lXLNo7A9J9GDsPMQUm0Pi0M/edit) and the [new course flow](https://docs.google.com/drawings/d/1DAhz464j1XDyQPoOH0adIwAceUwuGU1rqsWkVn8ZQ8I/edit) for context.
 
@@ -61,3 +62,5 @@ Further education screens are probably out of scope for MVP.
 | [Start date](#course-start-date) | Rarely edited | Low | Low | No |
 | [Title](#title) | Changes to titles need to be approved | Medium | High | No |
 | [Confirm changes](#confirm-your-change) | All edits must be summarised before confirming | High | High | -- |
+
+<!-- markdownlint-enable MD051 -->

--- a/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2019-04-22-publishing-during-rollover.md
@@ -11,6 +11,7 @@ screenshots:
     - Published course
     - Course with unpublished changes
 ---
+<!-- markdownlint-disable MD051 -->
 
 During rollover there are two cycles: the current cycle, and another that’s being prepared for the next cycle. Courses in the next cycle can’t go live until the cycle begins, which is usually in October.
 
@@ -81,3 +82,5 @@ Once a cycle has opened all changes should revert.
 We probably need a way for providers to preview their course after it’s been published, as View on website won’t be a thing.
 
 The preview links could persist on the course page and not be dependent on the course’s state.
+
+<!-- markdownlint-ensable MD051 -->


### PR DESCRIPTION
After an upgrade to the markdownlint-cli, linting was failing on `MD051/link-fragments Link fragments should be valid`

As a quick fix, I have disabled linting on the posts where the error occurred.