### PR TITLE
Move the post publication date to the header

### DIFF
--- a/app/_components/article/_article.scss
+++ b/app/_components/article/_article.scss
@@ -1,27 +1,11 @@
-.app-article__header {
-  margin-bottom: govuk-spacing(6);
-}
-
 .app-article__title {
   @include govuk-font($size: 48, $weight: bold);
   margin-top: 0;
-  margin-bottom: govuk-spacing(4);
+  margin-bottom: govuk-spacing(8);
 }
 
-.app-article__body {
-  @include govuk-responsive-margin(8, "bottom");
-
-  > *:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.app-article__footer {
+.app-article__metadata {
   @include govuk-font($size: 16, $line-height: 1.5);
-  border-top: 1px solid $govuk-border-colour;
-  padding-top: govuk-spacing(2);
-
-  @include govuk-media-query($from: "tablet") {
-    max-width: 66%;
-  }
+  color: $govuk-secondary-text-colour;
+  margin-top: govuk-spacing(4);
 }

--- a/app/_components/article/template.njk
+++ b/app/_components/article/template.njk
@@ -14,6 +14,18 @@
             text: params.header.tag | capitalize
           }) }}
         {% endif %}
+
+        <p class="app-article__metadata">
+          {% if params.header.date %}
+            <span class="govuk-visually-hidden">Posted on: </span><time datetime="{{ params.header.date | date }}">{{ params.header.date | date("d LLLL y") }}</time>
+          {% endif %}
+
+          {% if params.header.modified %}
+            <span aria-hidden="true">•</span>
+            Last updated <time datetime="{{ params.modified | date }}">{{ params.modified | date("d LLLL y") }}</time>
+          {% endif %}
+        </p>
+
       </div>
     </div>
   </header>
@@ -22,15 +34,4 @@
   <div class="app-article__body">
 {{- caller() if caller -}}
   </div>
-
-  {% if params.footer %}
-  <footer class="app-article__footer">
-    {% if params.footer.date %}
-      Published <time datetime="{{ params.footer.date | date }}">{{ params.footer.date | date("d LLLL y") }}</time><br>
-    {% endif %}
-    {% if params.footer.modified %}
-      Last updated <time datetime="{{ params.footer.modified | date }}">{{ params.footer.modified | date("d LLLL y") }}</time>
-    {% endif %}
-  </footer>
-  {% endif %}
 </article>

--- a/app/_layouts/post.njk
+++ b/app/_layouts/post.njk
@@ -9,11 +9,9 @@
   {% call appArticle({
     header: {
       title: title | widont,
-      tag: status
-    },
-    footer: {
       date: page.date,
-      modified: modified if modified
+      modified: modified if modified,
+      tag: status
     }
   }) %}
   <div class="govuk-grid-row">


### PR DESCRIPTION
The date that a post was published in the design history is a pretty important bit of context for the whole post.  Whilst this is included prominently in the index pages, if someone arrives at a post via a direct link, they won't see the date straight away as it was at the end of the post.

This moves it to the header, after the title and before the main content. This follows a similar change on the [GOV.UK Design history](https://design-history.herokuapp.com/what-is-a-design-history/) project.

### Screenshots

| | Before | After |
|--|--|--|
| **Header** |   ![Before-top](https://user-images.githubusercontent.com/30665/191786366-690b9ad9-659d-469c-bd40-3cbad87c076a.png) | ![after](https://user-images.githubusercontent.com/30665/191786427-96b7ca29-3b4a-469f-8c67-c66d04c3759f.png) |
| **Footer** | ![Before-footer](https://user-images.githubusercontent.com/30665/191786457-ddafd734-d6e3-44a2-837b-8d4ee32c26af.png) | ![After-footer](https://user-images.githubusercontent.com/30665/191786491-a8cdd5a6-67ea-46ac-b708-a4e62cefdc1e.png) |



