### PR TITLE
Simplify breadcrumbs: don’t show current page and use 'Home' for homepage

### DIFF
--- a/app/_components/breadcrumbs/_breadcrumbs.scss
+++ b/app/_components/breadcrumbs/_breadcrumbs.scss
@@ -16,11 +16,6 @@ $app-breadcrumbs-inverted-border-colour: govuk-colour("light-blue");
     border-color: $app-breadcrumbs-inverted-text-colour;
   }
 
-  .govuk-breadcrumbs__list-item:last-child a {
-    font-weight: bold;
-    text-decoration: none;
-  }
-
   a:link,
   a:visited,
   a:hover,

--- a/app/_components/breadcrumbs/template.njk
+++ b/app/_components/breadcrumbs/template.njk
@@ -6,6 +6,5 @@
       <a class="govuk-breadcrumbs__link" href="{{ item.url | url | pretty }}">{{ item.title }}</a>
     </li>
   {%- endfor %}
-    <li class="govuk-breadcrumbs__list-item" aria-current="page">{{ params.title }}</li>
   </ol>
 </div>

--- a/app/index.md
+++ b/app/index.md
@@ -5,5 +5,5 @@ description: A history of the designs for the Find, Apply, Publish, Manage, Regi
 eleventyComputed:
   eleventyNavigation:
     key: home
-    title: "{{ title }}"
+    title: Home
 ---


### PR DESCRIPTION
This updates the breadcrumb navigation to remove the current duplication of the name of the home page (which currently repeats the title in the black bar) and the name of the current page (which is also shown in the h1).

This follows the [GOV.UK Design System guidance for breadcrumbs](https://design-system.service.gov.uk/components/breadcrumbs/), which says:

> The breadcrumb should start with your ‘home’ page and end with the parent section of the current page.

(This change was also made [upstream in the GOV.UK Design History template repository](https://github.com/x-govuk/govuk-design-history/pull/188).)

## Screenshots

### Service page

| Before | After |
|---|---|
|  ![localhost_8080_apply-for-teacher-training_(iPhone 6_7_8) (2)](https://user-images.githubusercontent.com/30665/198544890-850b9ada-d7eb-4b52-9b06-d3bc1b7c7119.png) | ![localhost_8080_apply-for-teacher-training_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/30665/198544931-49812b44-cb55-4fda-aef1-91a052aa719d.png) |


### Post page

| Before | After |
|---|---|
| ![localhost_8080_apply-for-teacher-training_letting-candidates-deal-with-reference-requests-after-accepting-an-offer_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/30665/198545112-3c1a7e88-1cff-44a3-8020-3d1a784a9bf0.png) | ![localhost_8080_apply-for-teacher-training_letting-candidates-deal-with-reference-requests-after-accepting-an-offer_(iPhone 6_7_8)](https://user-images.githubusercontent.com/30665/198545177-0214db30-c129-4819-b71a-2a45e2e3fa98.png) |

