### PR TITLE
Fix: breadcrumb is broken where 2 pages have the same title

### DIFF
--- a/app/posts/find-teacher-training/2022-10-11-updating-information-about-bursaries-and-scholarships.md
+++ b/app/posts/find-teacher-training/2022-10-11-updating-information-about-bursaries-and-scholarships.md
@@ -20,6 +20,11 @@ screenshots:
       src: course-description--bursary.png
     - text: Course description - bursary and scholarship
       src: course-description--bursary-and-scholarship.png
+eleventyComputed:
+  eleventyNavigation:
+    key: find-updated-bursaries-and-scholarships
+    title: "{{ title }}"
+
 ---
 
 Candidates applying for teacher training courses in England may be eligible for a bursary or scholarship.

--- a/app/posts/find-teacher-training/2022-10-11-updating-information-about-bursaries-and-scholarships.md
+++ b/app/posts/find-teacher-training/2022-10-11-updating-information-about-bursaries-and-scholarships.md
@@ -23,8 +23,6 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: find-updated-bursaries-and-scholarships
-    title: "{{ title }}"
-
 ---
 
 Candidates applying for teacher training courses in England may be eligible for a bursary or scholarship.

--- a/app/posts/publish-teacher-training-courses/2022-03-25-adding-primary-navigation-to-the-service.md
+++ b/app/posts/publish-teacher-training-courses/2022-03-25-adding-primary-navigation-to-the-service.md
@@ -16,6 +16,9 @@ screenshots:
       src: organisation-list.png
     - text: Your account
       src: your-account.png
+eleventyComputed:
+  eleventyNavigation:
+    key: publish-adding-primary-navigation
 ---
 
 We have observed that users find it hard to navigate the service.

--- a/app/posts/publish-teacher-training-courses/2022-06-15-switching-between-recruitment-cycles-during-rollover.md
+++ b/app/posts/publish-teacher-training-courses/2022-06-15-switching-between-recruitment-cycles-during-rollover.md
@@ -10,6 +10,9 @@ screenshots:
       src: cycle-switcher--action-bar-single-organisation.png
     - text: Action bar - multiple organisation user
       src: cycle-switcher--action-bar-multiple-organisations.png
+eleventyComputed:
+  eleventyNavigation:
+    key: publish-switching-recruitment-cycles
 ---
 
 At the start of July each year, the process of rollover begins. During this period, users need to be able to see courses in the current recruitment cycle and prepare courses for publishing in the next recruitment cycle.

--- a/app/posts/publish-teacher-training-courses/2022-10-20-updating-information-about-bursaries-and-scholarships.md
+++ b/app/posts/publish-teacher-training-courses/2022-10-20-updating-information-about-bursaries-and-scholarships.md
@@ -20,6 +20,9 @@ screenshots:
       src: course-description--bursary.png
     - text: Course description - bursary and scholarship
       src: course-description--bursary-and-scholarship.png
+eleventyComputed:
+  eleventyNavigation:
+    key: publish-updated-bursaries-and-scholarships
 ---
 
 We recently [updated the bursary and scholarship information on Find postgraduate teacher training (Find)](/find-teacher-training/updating-bursary-and-scholarship-information/) following the publication of funding information for the 2023 to 2024 academic year.

--- a/app/posts/support-for-publish/2022-06-20-adding-primary-navigation-to-the-service.md
+++ b/app/posts/support-for-publish/2022-06-20-adding-primary-navigation-to-the-service.md
@@ -10,6 +10,9 @@ screenshots:
       src: primary-navigation--organisation-details.png
     - text: Primary navigation - edit organisation details
       src: primary-navigation--edit-organisation-details.png
+eleventyComputed:
+  eleventyNavigation:
+    key: support-adding-primary-navigation
 ---
 
 We recently added [primary navigation to the Publish teacher training courses service](/publish-teacher-training-courses/adding-primary-navigation-to-the-service/). We decided to do the same for the support website.

--- a/app/posts/support-for-publish/2022-07-20-switching-between-recruitment-cycles-during-rollover.md
+++ b/app/posts/support-for-publish/2022-07-20-switching-between-recruitment-cycles-during-rollover.md
@@ -12,6 +12,9 @@ screenshots:
       src: cycle-switcher--next-recruitment-cycle.png
     - text: Organisation details
       src: cycle-switcher--organisation-details.png
+eleventyComputed:
+  eleventyNavigation:
+    key: support-switching-recruitment-cycles
 ---
 
 At the start of July each year, the process of rollover begins. During this period, the support team need to be able to see courses in the current and next recruitment cycles to support the needs of our providers.


### PR DESCRIPTION
The eleventyNavigation plugin gets confused where there are 2 posts with the same title.

Simplest fix seems to be to manually give each post a unique "key" in the metadata...

Not sure if there’s a better way?