### PR TITLE
Show images in index pages

### DIFF
--- a/app/_components/document-list/_document-list.scss
+++ b/app/_components/document-list/_document-list.scss
@@ -20,6 +20,12 @@
   margin: 0 0 govuk-spacing(1);
 }
 
+.app-document-list__item-image {
+  margin-top: govuk-spacing(4);
+  width: 100%;
+  max-width: 100%;
+}
+
 .app-document-list__item-metadata {
   padding: 0;
   margin: 0;

--- a/app/_components/document-list/template.njk
+++ b/app/_components/document-list/template.njk
@@ -5,15 +5,20 @@
       <h2 class="app-document-list__item-title">
         <a class="govuk-link" href="{{ item.url | url | pretty }}">{{ item.data.title | nl2br | safe }}</a>
       </h2>
-      {% if item.data.description %}
-      <p class="app-document-list__item-description">{{ item.data.description | markdown("inline") | safe }}</p>
-      {% endif %}
       {% if item.date %}
       <ul class="app-document-list__item-metadata">
         <li class="app-document-list__attribute">
           <time datetime="{{ item.date | date }}">{{ item.date | date("d LLLL y") }}</time>
         </li>
       </ul>
+      {% endif %}
+
+      {% if item.data.ogImage.src %}
+        <img src="{{ item.data.ogImage.src }}" alt="{{ item.data.ogImage.alt }}" class="app-document-list__item-image" />
+      {% endif %}
+
+      {% if item.data.description %}
+      <p class="app-document-list__item-description">{{ item.data.description | markdown("inline") | safe }}</p>
       {% endif %}
     </li>
   {% endfor %}


### PR DESCRIPTION
This adds images to the index pages, where they are specified (as an `ogImage`) on the post.

Main reason is to add a bit of visual interest and possibly to make it easier to find relevant posts. Downside is it makes the page longer.  Possibly the image aspect ratios should a bit more wide (currently 3:2).

## Screenshot

![design-history-with-images](https://user-images.githubusercontent.com/30665/201352768-2417ae98-d6d4-4d12-97a3-aa16b203ee24.png)
