### PR TITLE
Update summary card component post

### DIFF
--- a/app/posts/apply-for-teacher-training/2020-03-13-summary-card-component.md
+++ b/app/posts/apply-for-teacher-training/2020-03-13-summary-card-component.md
@@ -13,6 +13,8 @@ related:
 
 {% from "gallery/macro.njk" import appGallery with context %}
 
+> On 31 January 2023, the summary card was incorporated into the GOV.UK Design System as [a new variant within the summary list component](https://design-system.service.gov.uk/components/summary-list/#summary-cards).
+
 Throughout the service we ask candidates to enter multiple items of information (eg jobs, work experiences, qualifications, course choices). We then give candidates the opportunity to review their answers, not only after completing each section, but when reviewing their entire application.
 
 We tried to display this information using existing components, but uncovered a number of different issues:


### PR DESCRIPTION
Closing the chapter on the summary card by updating the original post with an update on its inclusion in the GOV.UK Design History.