### PR TITLE
Add BAT domain to netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,12 @@
   status = 301
   force = true
 
+[[redirects]]
+  from = "/*"
+  to = "https://becoming-a-teacher.design-history.education.gov.uk/:splat"
+  status = 301
+  force = true
+
 [build]
   command = "npm run build"
   publish = "public"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
   force = true
 
 [[redirects]]
-  from = "/*"
+  from = "https://bat-design-history.netlify.app/*"
   to = "https://becoming-a-teacher.design-history.education.gov.uk/:splat"
   status = 301
   force = true


### PR DESCRIPTION
We now have an `education.gov.uk` domain for the BAT design history. 

This PR is to update the `netlify.toml` file to redirect to the [new domain](https://becoming-a-teacher.design-history.education.gov.uk/).