### PR TITLE
Remove reference to old BAT design history URL

### DIFF
--- a/app/posts/apply-for-teacher-training/2020-05-18-making-the-references-process-faster.md
+++ b/app/posts/apply-for-teacher-training/2020-05-18-making-the-references-process-faster.md
@@ -79,7 +79,7 @@ Because users will:
 * [have options](/apply-for-teacher-training/making-the-references-process-faster/#giving-options)
 * [know it's urgent](/apply-for-teacher-training/making-the-references-process-faster/#adding-urgency)
 
-### Examples of how the messaging works on the [interstitial page](https://bat-design-history.netlify.app/apply-for-teacher-training/add-a-new-referee#you-need-to-add-a-new-referee)
+### Examples of how the messaging works on the [interstitial page](/apply-for-teacher-training/add-a-new-referee#you-need-to-add-a-new-referee)
 
 #### 'Response overdue'
 
@@ -119,7 +119,7 @@ Because users will:
 
 ### Examples of how the messaging works with the reference status tags
 
-[Reference status tags](https://bat-design-history.netlify.app/apply-for-teacher-training/improving-the-references-user-journey/#what-this-looks-like) are not necessarily the best places for instructions: if a candidate cancels a reference and adds a new one, the cancelled tag will still show - meaning an instruction to 'add a new referee' would be out of date.
+[Reference status tags](/apply-for-teacher-training/improving-the-references-user-journey/#what-this-looks-like) are not necessarily the best places for instructions: if a candidate cancels a reference and adds a new one, the cancelled tag will still show - meaning an instruction to 'add a new referee' would be out of date.
 
 To avoid complexity and outdated content, we give instructions on the states which are likely to get updated:
 

--- a/app/posts/apply-for-teacher-training/2021-01-08-feedback-component-iteration.md
+++ b/app/posts/apply-for-teacher-training/2021-01-08-feedback-component-iteration.md
@@ -15,7 +15,7 @@ screenshots:
 related:
   items:
     - text: Prompting for feedback throughout the application journey
-      href: https://bat-design-history.netlify.app/apply-for-teacher-training/feedback-component/
+      href: /apply-for-teacher-training/feedback-component/
       description: Previous post outlining initial design
 ---
 

--- a/app/posts/find-teacher-training/2021-08-06-changes-to-find-at-the-end-of-2021-cycle.md
+++ b/app/posts/find-teacher-training/2021-08-06-changes-to-find-at-the-end-of-2021-cycle.md
@@ -52,7 +52,7 @@ After the deadline to apply for the first time, a new banner replaces the [previ
 
 It aims to discourage candidates applying for the first time from searching for courses because there's no guarantee that the courses shown (those starting in the 2021 to 2022 academic year) will be available the following year.
 
-[Learn what happens on Apply if a candidate starts an application but does not submit by their deadline](https://bat-design-history.netlify.app/apply-for-teacher-training/end-of-cycle-2021/#if-a-candidate-does-not-submit-by-their-deadline).
+[Learn what happens on Apply if a candidate starts an application but does not submit by their deadline](/apply-for-teacher-training/end-of-cycle-2021/#if-a-candidate-does-not-submit-by-their-deadline).
 
 ### If a candidate applying for the first time tries to select a course after the deadline
 

--- a/app/posts/manage-teacher-training-applications/2020-05-18-access-control-history.md
+++ b/app/posts/manage-teacher-training-applications/2020-05-18-access-control-history.md
@@ -341,8 +341,8 @@ Given the decision made, we spun up some prototypes to understand this complex l
 
 #### Design history
 
-- [Iteration 1](https://bat-design-history.netlify.app/manage-teacher-training-applications/setting-up-permissions)
-- [Iteration 2](https://bat-design-history.netlify.app/manage-teacher-training-applications/setting-up-permissions-iteration-2)
+- [Iteration 1](/manage-teacher-training-applications/setting-up-permissions)
+- [Iteration 2](/manage-teacher-training-applications/setting-up-permissions-iteration-2)
 
 #### Our design process
 

--- a/app/posts/manage-teacher-training-applications/2020-07-28-end-of-cycle-usability-research.md
+++ b/app/posts/manage-teacher-training-applications/2020-07-28-end-of-cycle-usability-research.md
@@ -17,18 +17,18 @@ We know that there are specific activities providers undertake when a recruitmen
 * planning a new cycle
 * data and reporting to DfE
 
-See the [previous entry for this research](https://bat-design-history.netlify.app/manage-teacher-training-applications/end-of-cycle-exploratory-research/).
+See the [previous entry for this research](/manage-teacher-training-applications/end-of-cycle-exploratory-research/).
 
 ## Context
 
 This round of research focused on the usability of designs around:
 
-* [switching cycles](https://bat-design-history.netlify.app/manage-teacher-training-applications/switching-between-cycles/)
-* [retrospectively marking conditions as met for applications from the previous cycle](https://bat-design-history.netlify.app/manage-teacher-training-applications/reconfirming-a-deferred-application/)
-* [deferring an application](https://bat-design-history.netlify.app/manage-teacher-training-applications/deferring-applications-to-the-next-cycle/)
-* [confirming deferrals](https://bat-design-history.netlify.app/manage-teacher-training-applications/reconfirming-a-deferred-application/)
+* [switching cycles](/manage-teacher-training-applications/switching-between-cycles/)
+* [retrospectively marking conditions as met for applications from the previous cycle](/manage-teacher-training-applications/reconfirming-a-deferred-application/)
+* [deferring an application](/manage-teacher-training-applications/deferring-applications-to-the-next-cycle/)
+* [confirming deferrals](/manage-teacher-training-applications/reconfirming-a-deferred-application/)
 
-We also looked at the new [application list task design and the activity log](https://bat-design-history.netlify.app/manage-teacher-training-applications/help-users-know-what-needs-doing-and-whats-changed/)
+We also looked at the new [application list task design and the activity log](/manage-teacher-training-applications/help-users-know-what-needs-doing-and-whats-changed/)
 
 ## Approach
 

--- a/app/posts/manage-teacher-training-applications/2021-04-08-gathering-school-direct-contact-details-from-higher-education-institutions.md
+++ b/app/posts/manage-teacher-training-applications/2021-04-08-gathering-school-direct-contact-details-from-higher-education-institutions.md
@@ -11,7 +11,7 @@ We’ve been looking at ways to help higher education institutions (HEIs) to:
 - set themselves up to use Manage
 - invite their school direct partners (SDs) to set themselves up
 
-We started by designing a [small online service that allowed HEIs to set themselves up and invite SDs](https://bat-design-history.netlify.app/manage-teacher-training-applications/self-service-registration/).
+We started by designing a [small online service that allowed HEIs to set themselves up and invite SDs](/manage-teacher-training-applications/self-service-registration/).
 
 After testing that design we decided to explore a simpler approach, focusing on gathering contact details for SDs from HEIs.
 

--- a/app/posts/manage-teacher-training-applications/2021-06-24-organisation-and-user-permissions-research.md
+++ b/app/posts/manage-teacher-training-applications/2021-06-24-organisation-and-user-permissions-research.md
@@ -7,9 +7,9 @@ related:
   - text: Research findings slides
     href: https://docs.google.com/presentation/d/1-NNXVPR68PbK84pU8yMmFpOZcRyJDPYdpdw3WNuYMxU/edit#slide=id.p3
   - text: Design history entry about displaying permissions in the user list
-    href: https://bat-design-history.netlify.app/manage-teacher-training-applications/displaying-permissions-in-the-user-list/
+    href: /manage-teacher-training-applications/displaying-permissions-in-the-user-list/
   - text: Design history entry about moving organisation permissions guidance
-    href: https://bat-design-history.netlify.app/manage-teacher-training-applications/moving-organisational-permissions-guidance-above-the-form/
+    href: /manage-teacher-training-applications/moving-organisational-permissions-guidance-above-the-form/
 screenshots:
   items:
     - text: Set up organisation permissions - start page

--- a/app/posts/manage-teacher-training-applications/2022-02-04-changing-course-when-there-are-upcoming-interviews-or-when-the-training-provider-is-changed.md
+++ b/app/posts/manage-teacher-training-applications/2022-02-04-changing-course-when-there-are-upcoming-interviews-or-when-the-training-provider-is-changed.md
@@ -16,7 +16,7 @@ tags:
   - interviews
 ---
 
-We recently designed a new flow to [let providers change the course before making an offer](https://bat-design-history.netlify.app/manage-teacher-training-applications/letting-providers-change-course-before-making-an-offer/).
+We recently designed a new flow to [let providers change the course before making an offer](/manage-teacher-training-applications/letting-providers-change-course-before-making-an-offer/).
 
 We did not consider what happens if:
 

--- a/app/posts/manage-teacher-training-applications/2022-03-28-changing-how-notes-are-displayed.md
+++ b/app/posts/manage-teacher-training-applications/2022-03-28-changing-how-notes-are-displayed.md
@@ -16,7 +16,7 @@ We recently gave users a way to [change and delete notes](/manage-teacher-traini
 
 We moved the name of the creator to above the note so that it’s immediately visible even if the note is long.
 
-We added ‘(you)’ next to the name of the note’s creator if it was created by the signed in user. This is to match how we indicate [applications which are assigned to the signed in user](https://bat-design-history.netlify.app/manage-teacher-training-applications/assigning-applications-to-users/).
+We added ‘(you)’ next to the name of the note’s creator if it was created by the signed in user. This is to match how we indicate [applications which are assigned to the signed in user](/manage-teacher-training-applications/assigning-applications-to-users/).
 
 We moved the date the note was created next to the name of the creator so that related information is grouped.
 

--- a/app/posts/publish-teacher-training-courses/2020-01-23-notifications-mvp.md
+++ b/app/posts/publish-teacher-training-courses/2020-01-23-notifications-mvp.md
@@ -7,7 +7,7 @@ tags:
 ---
 UCAS provided email notifications to it's users. This functionality is yet be introduced to Publish teacher training courses (Publish). To address this, we established an introductory set of notifications to satisfy our user’s critical needs.
 
-We learned through the [accredited bodies research](https://bat-design-history.netlify.com/publish-teacher-training-courses/accredited-bodies-research-round-2#a-need-for-notifications) that there was a need for notifications to be sent to accredited bodies about changes made in Publish.
+We learned through the [accredited bodies research](/publish-teacher-training-courses/accredited-bodies-research-round-2#a-need-for-notifications) that there was a need for notifications to be sent to accredited bodies about changes made in Publish.
 
 ## User needs
 

--- a/app/posts/publish-teacher-training-courses/2020-02-15-new-course-wizard-available.md
+++ b/app/posts/publish-teacher-training-courses/2020-02-15-new-course-wizard-available.md
@@ -31,7 +31,7 @@ School directs will not receive access to the new course wizard until Publish te
 
 An accredited body needs to be notified immediately so they can maintain accurate data in their record systems. This was highlighted in [Accredited bodies research - Reporting round 2](/publish-teacher-training-courses/accredited-bodies-research-round-2).
 
-Publish will shortly [provide these notifications](https://bat-design-history.netlify.com/publish-teacher-training-courses/notifications-mvp) to ensure this need is met. Once notifications are enabled all users will have access to the wizard.
+Publish will shortly [provide these notifications](/publish-teacher-training-courses/notifications-mvp) to ensure this need is met. Once notifications are enabled all users will have access to the wizard.
 
 ## Course creation for school directs
 

--- a/app/posts/publish-teacher-training-courses/2020-07-13-notifications-users-with-multiple-organisation-access.md
+++ b/app/posts/publish-teacher-training-courses/2020-07-13-notifications-users-with-multiple-organisation-access.md
@@ -156,7 +156,7 @@ In [previous research](/publish-teacher-training-courses/users-with-multiple-org
 
 This update includes:
 
-- simplifying the language used in the page title [(View the original)](https://bat-design-history.netlify.app/publish-teacher-training-courses/accredited-bodies-new-features/#notifications-opt-in)
+- simplifying the language used in the page title [(View the original)](/publish-teacher-training-courses/accredited-bodies-new-features/#notifications-opt-in)
 - updating content to list all available notifications
 - the ability for multi-organisation users to specify which training providers they want to receive notifications about
 

--- a/app/posts/publish-teacher-training-courses/2020-10-13-what-we-did-for-rollover-2020.md
+++ b/app/posts/publish-teacher-training-courses/2020-10-13-what-we-did-for-rollover-2020.md
@@ -266,7 +266,7 @@ https://github.com/DFE-Digital/teacher-training-api/pull/1589
 
 ### Course fees
 
-We [uncoupled EU from UK course fees](https://bat-design-history.netlify.app/publish-teacher-training-courses/uncoupling-UK-and-EU-course-fees/).
+We [uncoupled EU from UK course fees](/publish-teacher-training-courses/uncoupling-UK-and-EU-course-fees/).
 
 https://github.com/DFE-Digital/publish-teacher-training/pull/1374
 https://github.com/DFE-Digital/find-teacher-training/pull/458

--- a/app/posts/publish-teacher-training-courses/2023-04-19-managing-and-communicating-rollover-in-2022.md
+++ b/app/posts/publish-teacher-training-courses/2023-04-19-managing-and-communicating-rollover-in-2022.md
@@ -27,8 +27,8 @@ We wanted to make it easy for providers to reuse courses from the 2021 to 2022 r
 We did this by:
 
 - duplicating courses from the 2021 to 2022 recruitment cycle to the 2022 to 2023 recruitment cycle
-- giving users the ability to [switch between recruitment cycles]( https://bat-design-history.netlify.app/publish-teacher-training-courses/switching-between-recruitment-cycles-during-rollover/)
-- allowing users to [manually rollover courses not previously published]( https://bat-design-history.netlify.app/publish-teacher-training-courses/allowing-users-to-manually-rollover-courses-not-previously-published/)
+- giving users the ability to [switch between recruitment cycles](/publish-teacher-training-courses/switching-between-recruitment-cycles-during-rollover/)
+- allowing users to [manually rollover courses not previously published](/publish-teacher-training-courses/allowing-users-to-manually-rollover-courses-not-previously-published/)
 - sending a series of emails to providers about the rollover process
 
 ## Timeline

--- a/app/posts/register-trainee-teachers/2021-02-16-multiple-providers.md
+++ b/app/posts/register-trainee-teachers/2021-02-16-multiple-providers.md
@@ -10,7 +10,7 @@ related:
 
 So far, our prototype has been designed to work the simple case - users who work for a single provider. We’re now extending that to look at how it could work for different organisational setups.
 
-In the current DTTP service, trainees are added by accredited providers. The majority of our users work for a single accredited provider, but often a provider represents a partnership of multiple schools, and so about [20% of current DTTP users](https://bat-design-history.netlify.app/publish-teacher-training-courses/users-with-multiple-organisation-access/) are responsible for inputting ITT data across multiple schools.
+In the current DTTP service, trainees are added by accredited providers. The majority of our users work for a single accredited provider, but often a provider represents a partnership of multiple schools, and so about [20% of current DTTP users](/publish-teacher-training-courses/users-with-multiple-organisation-access/) are responsible for inputting ITT data across multiple schools.
 
 Our first step towards supporting multiple providers was looking at how DTTP, Manage and Publish handle them.
 


### PR DESCRIPTION
This PR removes `https://bat-design-history.netlify.app` from URLs.