### PR TITLE
Add post: Emailing support users

### DIFF
--- a/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
+++ b/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
@@ -1,0 +1,58 @@
+---
+title: Emailing support users
+description: We email support users when they have been added or removed from the service
+date: 2024-05-01
+tags:
+  - emails
+---
+
+<!-- markdownlint-disable MD001 MD025 -->
+{% from "email/macro.njk" import appEmail %}
+
+We email support users when they have been added or removed from the service by another support user.
+
+## Support user added
+
+{{ appEmail({
+subject: "Invitation to join Claim funding for mentor training",
+content: "
+Dear ((firstname)),
+
+You have been invited to join the Claim funding for mentor training service.
+
+# Sign in to the support site
+
+If you have a DfE Sign-in account, you can use it to sign in:
+
+https://claim-funding-for-mentor-training.education.gov.uk/sign-in
+
+If you need to create a DfE Sign-in account, you can do this after clicking ‘Sign in using DfE Sign-in’.
+
+After creating a DfE Sign-in account, must to return to this email and [sign in to access the service](https://claim-funding-for-mentor-training.education.gov.uk/sign-in).
+
+# Give feedback or report a problem
+
+If you have any questions or feedback, please [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C0657JE64HX).
+
+Regards
+Claim funding for mentor training team
+"
+}) }}
+
+## Support user removed
+
+{{ appEmail({
+subject: "You have been removed from Claim funding for mentor training",
+content: "
+Dear ((firstname)),
+
+You have been removed from the Claim funding for mentor training service.
+
+If you think this was a mistake, [contact the service team on Slack](https://ukgovernmentdfe.slack.com/archives/C0657JE64HX).
+
+Regards
+Claim funding for mentor training team
+"
+}) }}
+
+<!-- markdownlint-enable MD001 MD025 -->

--- a/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
+++ b/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
@@ -7,6 +7,8 @@ tags:
   - users
 related:
   items:
+    - text: Managing support users
+      href: /claim-funding-for-mentors/managing-support-users/
     - text: Emailing school users
       href: /claim-funding-for-mentors/emailing-school-users/
 ---

--- a/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
+++ b/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
@@ -1,7 +1,7 @@
 ---
 title: Emailing support users
 description: We email support users when they have been added or removed from the service
-date: 2024-05-01
+date: 2024-05-01T12:00:00+00:00
 tags:
   - emails
 ---

--- a/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
+++ b/app/posts/claim-funding-for-mentors/2024-05-01-emailing-support-users.md
@@ -4,6 +4,11 @@ description: We email support users when they have been added or removed from th
 date: 2024-05-01T12:00:00+00:00
 tags:
   - emails
+  - users
+related:
+  items:
+    - text: Emailing school users
+      href: /claim-funding-for-mentors/emailing-school-users/
 ---
 
 <!-- markdownlint-disable MD001 MD025 -->


### PR DESCRIPTION
We email support users when they have been added or removed from the service by another support user.