### PR TITLE
Fix post breadcrumbs

### DIFF
--- a/app/posts/manage-teacher-training-applications/2022-01-26-indicating-unanswered-questions-with-not-entered.md
+++ b/app/posts/manage-teacher-training-applications/2022-01-26-indicating-unanswered-questions-with-not-entered.md
@@ -1,13 +1,16 @@
 ---
 title: Indicating unanswered questions with ‘not entered’
-description: We made sure we’re consistent in how we indicate that a candidate did not answer a question.
+description: We made sure we’re consistent in how we indicate that a candidate did not answer a question
 date: 2022-01-24
+tags:
+  - application details
 screenshots:
   items:
     - text: Application details
       src: application-details.png
-tags:
-  - application details
+eleventyComputed:
+  eleventyNavigation:
+    key: manage-indicating-unanswered-questions
 ---
 
 At the moment, we’re inconsistent in how we indicate that a candidate did not answer a question.

--- a/app/posts/publish-teacher-training-courses/2022-06-30-indicating-unanswered-questions-with-not-entered.md
+++ b/app/posts/publish-teacher-training-courses/2022-06-30-indicating-unanswered-questions-with-not-entered.md
@@ -8,6 +8,9 @@ screenshots:
   items:
     - text: Course description
       src: course-description.png
+eleventyComputed:
+  eleventyNavigation:
+    key: publish-indicating-unanswered-questions
 ---
 
 At the moment, when a user has not answered a question, we indicate this with the word ‘empty’.


### PR DESCRIPTION
Manage and Publish have posts with the same page slug. Therefore, the breadcrumb shows both Manage and Publish links, which is incorrect.

To fix this, we can use the following code in the frontmatter:

```
eleventyComputed:
  eleventyNavigation:
    key: SOME UNIQUE KEY
```

Pages:

- `/manage-teacher-training-applications/indicating-unanswered-questions-with-not-entered/`
- `/publish-teacher-training-courses/indicating-unanswered-questions-with-not-entered/`