### PR TITLE
Move JavaScripts to the assets folder

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -78,9 +78,9 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="/javascripts/govuk-frontend.js" type="module"></script>
+  <script src="/assets/scripts/govuk-frontend.js" type="module"></script>
   {% block scripts %}
-    <script src="/javascripts/application.js"></script>
+    <script src="/assets/scripts/application.js"></script>
     {% block pageScripts %}{% endblock %}
   {% endblock %}
 {% endblock %}

--- a/etc/rollup.config.js
+++ b/etc/rollup.config.js
@@ -4,7 +4,7 @@ const commonjs = require('@rollup/plugin-commonjs')
 module.exports = [{
   input: 'app/_javascripts/application.js',
   output: {
-    file: 'public/javascripts/application.js',
+    file: 'public/assets/scripts/application.js',
     format: 'iife'
   },
   plugins: [
@@ -14,7 +14,7 @@ module.exports = [{
 }, {
   input: 'node_modules/govuk-frontend/dist/govuk/govuk-frontend.min.js',
   output: {
-    file: 'public/javascripts/govuk-frontend.js'
+    file: 'public/assets/scripts/govuk-frontend.js'
   },
   context: 'window'
 }]


### PR DESCRIPTION
We have `fonts`, `images` and `styles` in the `/assets` folder. To be consistent, this PR moves the JavaScripts there too.