### PR TITLE
Remove govuk-frontend table macro and use markdown tables

### DIFF
--- a/app/posts/apply-for-teacher-training/2021-03-31-dashboard-changes.md
+++ b/app/posts/apply-for-teacher-training/2021-03-31-dashboard-changes.md
@@ -29,8 +29,6 @@ related:
       description: Previous post about dashboard states
 ---
 
-{% from "../../../node_modules/govuk-frontend/dist/govuk/components/table/macro.njk" import govukTable with context %}
-
 The ‘dashboard’ is the name we use internally for the page a candidate sees after they have submitted their application.
 
 It lists the applications a candidate has made and the stage they are at in the application process. They can complete tasks there too, such as accepting an offer, or withdrawing an application.
@@ -43,16 +41,16 @@ Research from 2020 told us that candidates didn’t realise that their applicati
 
 The objective of our work has been to:
 
-* Help candidates realise that they can return to the dashboard, and that it’s the ‘home’ of their applications.
-* Make sure the dashboard gives the right information at the right stage. For example, pointing to teacher training advisers for help with interviews, or getting candidates who have been unsuccessful to apply again.
+- Help candidates realise that they can return to the dashboard, and that it’s the ‘home’ of their applications.
+- Make sure the dashboard gives the right information at the right stage. For example, pointing to teacher training advisers for help with interviews, or getting candidates who have been unsuccessful to apply again.
 
 ## What’s changed
 
 We made changes to:
 
-* The flow for how candidates get to the dashboard after submitting an application
-* The layout of the dashboard
-* The content presented on the dashboard
+- The flow for how candidates get to the dashboard after submitting an application
+- The layout of the dashboard
+- The content presented on the dashboard
 
 ### Post-submission flow
 
@@ -84,163 +82,39 @@ Part of the dashboard work has been to define the different states an applicatio
 
 We added each state to the prototype to make it easier to iterate the design and content.
 
-{{ govukTable({
-  caption: "Applications to a single course",
-  captionClasses: "govuk-table__caption--m",
-  firstCellIsHeader: false,
-  head: [{
-    text: "Application status"
-  }, {
-    text: "Candidate next steps"
-  }],
-  rows: [
-    [{
-      text: "Awaiting decision from provider"
-    }, {
-      text: "Wait for a decision"
-    }],
-    [{
-      text: "Interview scheduled in future"
-    }, {
-      text: "Attend interview / contact teacher training adviser to help prepare."
-    }],
-    [{
-      text: "After interview, still awaiting decision"
-    }, {
-      text: "Wait for decision"
-    }],
-    [{
-      text: "Received an offer with conditions"
-    }, {
-      text: "Respond to offer"
-    }],
-    [{
-      text: "Received an offer for a different course"
-    }, {
-      text: "Respond to offer"
-    }],
-    [{
-      text: "Received an offer from a course from a different provider"
-    }, {
-      text: "Respond to offer"
-    }],
-    [{
-      text: "Unsuccessful - provider has given feedback"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Unsuccessful - course was full"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Unsuccessful - provider did not respond in time"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Candidate withdrew application"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Offer withdrawn by provider"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Accepted (pending conditions)"
-    }, {
-      text: "Meet conditions"
-    }],
-    [{
-      text: "Declined"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Deferred"
-    }, {
-      text: "Meet conditions before deferral start date"
-    }],
-    [{
-      text: "Candidate did not respond to offer in time"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Candidate did not meet offer conditions"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Candidate recruited"
-    }, {
-      text: "No nudges given"
-    }]
-  ]
-}) }}
+#### Applications to a single course
 
-{{ govukTable({
-  caption: "Applications for multiple courses",
-  captionClasses: "govuk-table__caption--m",
-  firstCellIsHeader: false,
-  head: [{
-    text: "Application status"
-  }, {
-    text: "Candidate next steps"
-  }],
-  rows: [
-    [{
-      text: "Awaiting decisions from all providers"
-    }, {
-      text: "Wait for a decision"
-    }],
-    [{
-      text: "Interviewing"
-    }, {
-      text: "Attend interview / contact teacher training adviser to help prepare."
-    }],
-    [{
-      text: "One offer received, still awaiting one more provider decision"
-    }, {
-      text: "Wait for all decisions to be made"
-    }],
-    [{
-      text: "Two rejections received, still awaiting third provider decision"
-    }, {
-      text: "Wait for all decisions to be made"
-    }],
-    [{
-      text: "Received one offer"
-    }, {
-      text: "Respond to offer"
-    }],
-    [{
-      text: "Received two offers"
-    }, {
-      text: "Respond to offer"
-    }],
-    [{
-      text: "Ended without success"
-    }, {
-      text: "Apply again"
-    }],
-    [{
-      text: "Accepted offer, pending conditions"
-    }, {
-      text: "Meet conditions"
-    }],
-    [{
-      text: "Offer deferred"
-    }, {
-      text: "Meet conditions before deferral start date"
-    }],
-    [{
-      text: "Recruited"
-    }, {
-      text: "No nudges given"
-    }]
-  ]
-}) }}
+| Application status | Candidate next steps |
+| --- | --- |
+|Awaiting decision from provider|Wait for a decision|
+|Interview scheduled in future|Attend interview / contact teacher training adviser to help prepare.|
+|After interview, still awaiting decision|Wait for decision|
+|Received an offer with conditions|Respond to offer|
+|Received an offer for a different course|Respond to offer|
+|Received an offer from a course from a different provider|Respond to offer|
+|Unsuccessful - provider has given feedback|Apply again|
+|Unsuccessful - course was full|Apply again|
+|Unsuccessful - provider did not respond in time|Apply again|
+|Candidate withdrew application|Apply again|
+|Offer withdrawn by provider|Apply again|
+|Accepted (pending conditions)|Meet conditions|
+|Declined|Apply again|
+|Deferred|Meet conditions before deferral start date|
+|Candidate did not respond to offer in time|Apply again|
+|Candidate did not meet offer conditions|Apply again|
+|Candidate recruited|No nudges given|
+
+#### Applications for multiple courses
+
+| Application status | Candidate next steps |
+| --- | --- |
+|Awaiting decisions from all providers|Wait for a decision|
+|Interviewing|Attend interview / contact teacher training adviser to help prepare.|
+|One offer received, still awaiting one more provider decision|Wait for all decisions to be made|
+|Two rejections received, still awaiting third provider decision|Wait for all decisions to be made|
+|Received one offer|Respond to offer|
+|Received two offers|Respond to offer|
+|Ended without success|Apply again|
+|Accepted offer, pending conditions|Meet conditions|
+|Offer deferred|Meet conditions before deferral start date|
+|Recruited|No nudges given|

--- a/app/posts/apply-for-teacher-training/2021-09-22-degree-grade-requirement-warning-message.md
+++ b/app/posts/apply-for-teacher-training/2021-09-22-degree-grade-requirement-warning-message.md
@@ -17,8 +17,6 @@ related:
       description: Post about collecting degree entry requirements on Publish.
 ---
 
-{% from "../../../node_modules/govuk-frontend/dist/govuk/components/table/macro.njk" import govukTable with context %}
-
 One of the reasons why providers reject candidates is because they do not have the right degree grade (for example 2:1 or above).
 
 Each course has a different minimum degree requirement. While some courses accept any honours degree, most ask for a minimum grade.
@@ -27,8 +25,8 @@ This is particularly challenging for candidates with a third-class degree.
 
 We realised that we could help candidates by:
 
-* showing the minimum degree requirement for each course (on Find)
-* warning them if they’ve chosen a course that may not accept their degree grade
+- showing the minimum degree requirement for each course (on Find)
+- warning them if they’ve chosen a course that may not accept their degree grade
 
 ## Showing minimum degree requirements on Find
 


### PR DESCRIPTION
We don't need to use the govuk-frontend macro for tables, as markdown natively handles tables. Several posts already use the markdown equivalent.

This PR cleans up the remaining post: [Dashboard changes](https://deploy-preview-1218--bat-design-history.netlify.app/apply-for-teacher-training/dashboard-changes/)