### PR TITLE
Add addPassthroughCopy for image assets

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -34,6 +34,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addFilter('widont', require('./lib/filters/widont'))
 
   // Passthrough
+  eleventyConfig.addPassthroughCopy('./app/assets/images')
   eleventyConfig.addPassthroughCopy('./app/documents')
   eleventyConfig.addPassthroughCopy({ './app/images': '.' })
   eleventyConfig.addPassthroughCopy({ 'node_modules/govuk-frontend/dist/govuk/assets': 'assets' })


### PR DESCRIPTION
Now that we have an `app/assets/image` directory, we need to configure Eleventy to copy the assets to the `public/assets/images` directory.

This will fix a broken `opengraph-image.png` reference.