### PR TITLE
Update 'Get Into Teaching' design history URL

### DIFF
--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -68,7 +68,7 @@
     meta: {
       items: [{
         text: "Get Into Teaching design history",
-        href: "https://get-into-teaching-design-history.netlify.app"
+        href: "https://git-design-history.netlify.app"
       }, {
         text: "GitHub",
         href: "https://github.com/dfe-digital/bat-design-history"


### PR DESCRIPTION
The Get Into Teaching design history site has moved from:

`https://get-into-teaching-design-history.netlify.app`

to:

`https://git-design-history.netlify.app`