### PR TITLE
Add ‘How to’ section

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -100,7 +100,7 @@ module.exports = function (eleventyConfig) {
     return collectionApi.getFilteredByGlob(['app/glossary.md',
       'app/mission-patches.md',
       'app/service-map.md',
-      'app/how-to/how-to.md'
+      'app/posts/how-to/how-to.md'
     ])
   })
 

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -96,9 +96,13 @@ module.exports = function (eleventyConfig) {
     return collection.getFilteredByGlob('app/posts/support-for-publish/*.md')
   })
 
+  eleventyConfig.addCollection('how-to', collection => {
+    return collection.getFilteredByGlob('app/posts/how-to/*.md')
+  })
+
   // A collection of reference pages
   eleventyConfig.addCollection('reference', collectionApi => {
-    return collectionApi.getFilteredByGlob(['app/glossary.md', 'app/mission-patches.md', 'app/service-map.md'])
+    return collectionApi.getFilteredByGlob(['app/glossary.md', 'app/mission-patches.md', 'app/service-map.md', 'app/how-to/how-to.md'])
   })
 
   // A collection of user need pages

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,7 +35,6 @@ module.exports = function (eleventyConfig) {
 
   // Passthrough
   eleventyConfig.addPassthroughCopy('./app/assets/images')
-  eleventyConfig.addPassthroughCopy('./app/documents')
   eleventyConfig.addPassthroughCopy({ './app/images': '.' })
   eleventyConfig.addPassthroughCopy({ 'node_modules/govuk-frontend/dist/govuk/assets': 'assets' })
 
@@ -96,13 +95,18 @@ module.exports = function (eleventyConfig) {
     return collection.getFilteredByGlob('app/posts/support-for-publish/*.md')
   })
 
-  eleventyConfig.addCollection('how-to', collection => {
-    return collection.getFilteredByGlob('app/posts/how-to/*.md')
-  })
-
   // A collection of reference pages
   eleventyConfig.addCollection('reference', collectionApi => {
-    return collectionApi.getFilteredByGlob(['app/glossary.md', 'app/mission-patches.md', 'app/service-map.md', 'app/how-to/how-to.md'])
+    return collectionApi.getFilteredByGlob(['app/glossary.md',
+      'app/mission-patches.md',
+      'app/service-map.md',
+      'app/how-to/how-to.md'
+    ])
+  })
+
+  // Collections of posts for each reference section
+  eleventyConfig.addCollection('how-to', collection => {
+    return collection.getFilteredByGlob('app/posts/how-to/*.md')
   })
 
   // A collection of user need pages

--- a/app/posts/how-to/how-to.json
+++ b/app/posts/how-to/how-to.json
@@ -1,0 +1,5 @@
+{
+  "eleventyNavigation": {
+    "parent": "How to"
+  }
+}

--- a/app/posts/how-to/how-to.md
+++ b/app/posts/how-to/how-to.md
@@ -1,7 +1,7 @@
 ---
 layout: collection
 title: How to
-description: A collection of guides to help you build and document our services.
+description: A collection of guides to help you build and document Becoming a teacher services.
 pagination:
   data: collections.how-to
   reverse: true

--- a/app/posts/how-to/how-to.md
+++ b/app/posts/how-to/how-to.md
@@ -1,7 +1,7 @@
 ---
 layout: collection
 title: How to
-description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed accumsan odio in nulla eleifend, ut pulvinar dui fringilla.
+description: A collection of guides to help you build and document our services.
 pagination:
   data: collections.how-to
   reverse: true

--- a/app/posts/how-to/how-to.md
+++ b/app/posts/how-to/how-to.md
@@ -1,0 +1,15 @@
+---
+layout: collection
+title: How to
+description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed accumsan odio in nulla eleifend, ut pulvinar dui fringilla.
+pagination:
+  data: collections.how-to
+  reverse: true
+  size: 50
+permalink: "how-to/{% if pagination.pageNumber > 0 %}page/{{ pagination.pageNumber + 1 }}{% endif %}/"
+eleventyComputed:
+  eleventyNavigation:
+    key: "{{ title }}"
+    excerpt: "{{ description }}"
+    parent: home
+---


### PR DESCRIPTION
This PR sets up a section called 'How to' to house a collection of guides to help you build and document our services.

Note: The section is hidden until the first post is published.