### PR TITLE
Using HESA to submit trainee records for 2024 to 2025

### DIFF
--- a/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
+++ b/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
@@ -10,7 +10,6 @@
 
 For the 2024 to 2025 academic year, new partnerships between Higher Education Institutions (HEIs) will be introduced. Some providers will now be responsible for trainee records on behalf of their partners. The Register trainee teachers (Register) team needed to decide how to support these partnerships to submit and manage trainee recrods.
 
-
 ## How DfE collects data on trainee teachers studying at HEIs
 
 HEIs submit ITT trainee data to Register trainee teachers (Register) using the Higher Education Statistics Authority (HESA).
@@ -18,7 +17,6 @@ HEIs submit ITT trainee data to Register trainee teachers (Register) using the H
 HESA collects data on every student at university in England. HESA also runs the ‘ITT collection’, an additional data collection for ITT trainees on behalf of the DfE. The ITT collection is submitted to and stored in Register. The ITT collection is the source of around 80% of the data in ITT census and ‘Performance profiles’ publications produced by the Teacher Analytics Division (TAD).
 
 The 2024 to 2025 academic year will be last time DfE uses HESA to collect data about ITT trainees at HEIs. From 2025 to 2026 onwards, HEIs will submit their data directly to DfE.
-
 
 ## Changes to how ITT providers organise themselves
 
@@ -29,7 +27,6 @@ Some of the providers who will lose accreditation have formed partnerships with 
 Accredited providers are responsible for submitting all trainee records. This includes anyone who is directly trained by a lead provider.
 
 Because lead partners are not responsible for trainee records, they can view their trainee records but do not have permission to create or edit trainee records in Register.
-
 
 ## Supporting accredited providers and lead partners to submit trainee data
 
@@ -47,14 +44,13 @@ Asking lead partners to send their data to accredited providers and then submit 
 
 We decided it was necessary to let lead partners submit ITT trainee data through HESA as they are used to. Register will then associate the trainee records with the corresponding accredited provider.
 
-
 ### Associating trainee records to the correct accredited provider
 
 We explored with HESA using the SDLEAD field for Lead Partners to indicate their accredited provider by reference to that organisation’s unique reference number (URN). However, this would require significant manual intervention by the lead partner before submitting to HESA, which seemed burdensome and potentially error prone.
 
 Instead, we will attribute records to the correct accredited provider after receiving them.
 
-We will decide the best way to do this accurately. Publish teacher training courses (Publish) has organisation types that Register can reference, however: 
+We will decide the best way to do this accurately. Publish teacher training courses (Publish) has organisation types that Register can reference, however:
 
 - it will take significant work to automate
 
@@ -62,18 +58,15 @@ We will decide the best way to do this accurately. Publish teacher training cour
 
 - this partnership information is up to 9 months old and may not have been kept up to date
 
-
 ### Managing sign off by accredited providers
 
 Accredited providers are responsible for ensuring the accuracy of trainee records. Lead partners submitting trainee records via HESA means that accredited providers will be accountable for signing off ITT collection records they did not submit.
 
 We will communicate to Register users to make this clear. We will also offer support in cases where there are unintended implications for the agreement between the accredited provider and lead partner.
 
-
 ### Lead partners cannot edit any trainee records in Register
 
 Register only permits lead partners read access to their trainee records. However, if they make changes to a trainee record in their student record system, it will be updated in Register via HESA. Accredited providers can make changes including awarding teacher status for all their trainee records in Register.
-
 
 ## Next steps
 

--- a/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
+++ b/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
@@ -12,7 +12,7 @@ For the 2024 to 2025 academic year, new partnerships between Higher Education In
 
 ## How DfE collects data on trainee teachers studying at HEIs
 
-HEIs submit ITT trainee data to Register trainee teachers (Register) using the Higher Education Statistics Authority (HESA).
+HEIs submit initial teacher training (ITT) trainee data to Register trainee teachers (Register) using the Higher Education Statistics Authority (HESA).
 
 HESA collects data on every student at university in England. HESA also runs the ‘ITT collection’, an additional data collection for ITT trainees on behalf of the DfE. The ITT collection is submitted to and stored in Register. The ITT collection is the source of around 80% of the data in ITT census and ‘Performance profiles’ publications produced by the Teacher Analytics Division (TAD).
 

--- a/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
+++ b/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
@@ -46,7 +46,7 @@ We decided it was necessary to let lead partners submit ITT trainee data through
 
 ### Associating trainee records to the correct accredited provider
 
-We explored with HESA using the SDLEAD field for lead partners to indicate their accredited provider by reference to that organisation’s unique reference number (URN). However, this would require significant manual intervention by the lead partner before submitting to HESA, which seemed burdensome and potentially error prone.
+We explored with HESA using the `SDLEAD` field for lead partners to indicate their accredited provider by reference to that organisation’s unique reference number (URN). However, this would require significant manual intervention by the lead partner before submitting to HESA, which seemed burdensome and potentially error prone.
 
 Instead, we will attribute records to the correct accredited provider after receiving them.
 

--- a/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
+++ b/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
@@ -1,0 +1,84 @@
+---
+  title:        Using HESA to submit trainee records for 2024 to 2025
+  description:  How lead partners and accredited providers will use HESA to submit trainee records in the 2024 to 2025 academic year
+  date:         2024-07-30
+  tags:
+    - ITT reform
+    - providers
+    - hesa
+---
+
+For the 2024 to 2025 academic year, new partnerships between Higher Education Institutions (HEIs) will be introduced. Some providers will now be responsible for trainee records on behalf of their partners. The Register trainee teachers (Register) team needed to decide how to support these partnerships to submit and manage trainee recrods.
+
+
+## How DfE collects data on trainee teachers studying at HEIs
+
+HEIs submit ITT trainee data to Register trainee teachers (Register) using the Higher Education Statistics Authority (HESA).
+
+HESA collects data on every student at university in England. HESA also runs the ‘ITT collection’, an additional data collection for ITT trainees on behalf of the DfE. The ITT collection is submitted to and stored in Register. The ITT collection is the source of around 80% of the data in ITT census and ‘Performance profiles’ publications produced by the Teacher Analytics Division (TAD).
+
+The 2024 to 2025 academic year will be last time DfE uses HESA to collect data about ITT trainees at HEIs. From 2025 to 2026 onwards, HEIs will submit their data directly to DfE.
+
+
+## Changes to how ITT providers organise themselves
+
+Some ITT providers will lose their accreditation from 1 August 2024. They will no longer be able to offer ITT to anyone new. They will still be able to train and award teacher status to anyone who started training before 1 August 2024.
+
+Some of the providers who will lose accreditation have formed partnerships with providers that kept their accreditation. The providers who lost their accreditation will become ‘Lead partners’, delivering training but not able to award teacher status.
+
+Accredited providers are responsible for submitting all trainee records. This includes anyone who is directly trained by a lead provider.
+
+Because lead partners are not responsible for trainee records, they can view their trainee records but do not have permission to create or edit trainee records in Register.
+
+
+## Supporting accredited providers and lead partners to submit trainee data
+
+In most cases where there is an accredited provider and a lead partner, ITT trainees will be located with their lead partner. We expect lead partners to use their student record system to track trainees, just like they did before losing ITT accreditation.
+
+Lead partners are still training providers, mostly universities, responsible for tens of thousands of students, with ITT trainees making up only a small percentage of their student population.
+
+To follow the strictest interpretation of the responsibilities between an accredited provider and a lead partner, all records should be created and submitted by the accredited provider.
+
+We considered if it was possible to help accredited providers submit records for all their trainees, including ones studying with lead partners. The two possible options were either making changes to how HESA worked or creating a scenario where it was likely that lead partners would need to transfer trainee records to their accredited provider.
+
+With a year left of HESA performing the ITT collection and a relatively short time to make the change, it was not practical to make changes to how HESA operates.
+
+Asking lead partners to send their data to accredited providers and then submit it to Register is likely to create a large administrative burden for both parties and invites an unacceptable level of risk.
+
+We decided it was necessary to let lead partners submit ITT trainee data through HESA as they are used to. Register will then associate the trainee records with the corresponding accredited provider.
+
+
+### Associating trainee records to the correct accredited provider
+
+We explored with HESA using the SDLEAD field for Lead Partners to indicate their accredited provider by reference to that organisation’s unique reference number (URN). However, this would require significant manual intervention by the lead partner before submitting to HESA, which seemed burdensome and potentially error prone.
+
+Instead, we will attribute records to the correct accredited provider after receiving them.
+
+We will decide the best way to do this accurately. Publish teacher training courses (Publish) has organisation types that Register can reference, however: 
+
+- it will take significant work to automate
+
+- the organisation types are not identical as Register (‘Training partners’ instead of ‘Lead partners’)
+
+- this partnership information is up to 9 months old and may not have been kept up to date
+
+
+### Managing sign off by accredited providers
+
+Accredited providers are responsible for ensuring the accuracy of trainee records. Lead partners submitting trainee records via HESA means that accredited providers will be accountable for signing off ITT collection records they did not submit.
+
+We will communicate to Register users to make this clear. We will also offer support in cases where there are unintended implications for the agreement between the accredited provider and lead partner.
+
+
+### Lead partners cannot edit any trainee records in Register
+
+Register only permits lead partners read access to their trainee records. However, if they make changes to a trainee record in their student record system, it will be updated in Register via HESA. Accredited providers can make changes including awarding teacher status for all their trainee records in Register.
+
+
+## Next steps
+
+In the short term we will create the process for associating lead partner trainees with the correct accredited provider and communicate these changes to the sector.
+
+From 1 August 2024 onwards the Register team and BAT (Becoming a teacher) support will monitor record submission so any problems arising are resolved quickly during the 2024 to 2025 academic year.
+
+In the long-term we will plan how to best to help accredited providers and lead partners submit data in a way that is simple and allows for the correct oversight.

--- a/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
+++ b/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
@@ -46,7 +46,7 @@ We decided it was necessary to let lead partners submit ITT trainee data through
 
 ### Associating trainee records to the correct accredited provider
 
-We explored with HESA using the SDLEAD field for Lead Partners to indicate their accredited provider by reference to that organisation’s unique reference number (URN). However, this would require significant manual intervention by the lead partner before submitting to HESA, which seemed burdensome and potentially error prone.
+We explored with HESA using the SDLEAD field for lead partners to indicate their accredited provider by reference to that organisation’s unique reference number (URN). However, this would require significant manual intervention by the lead partner before submitting to HESA, which seemed burdensome and potentially error prone.
 
 Instead, we will attribute records to the correct accredited provider after receiving them.
 

--- a/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
+++ b/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
@@ -50,13 +50,7 @@ We explored with HESA using the `SDLEAD` field for lead partners to indicate the
 
 Instead, we will attribute records to the correct accredited provider after receiving them.
 
-We will decide the best way to do this accurately. Publish teacher training courses (Publish) has organisation types that Register can reference, however:
-
-- it will take significant work to automate
-
-- the organisation types are not identical as Register (‘Training partners’ instead of ‘Lead partners’)
-
-- this partnership information is up to 9 months old and may not have been kept up to date
+We will decide the best way to do this accurately. Publish teacher training courses (Publish) has organisation types that Register can reference, however it will take significant work to automate and this partnership information is up to 9 months old and may not have been kept up to date.
 
 ### Managing sign off by accredited providers
 

--- a/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
+++ b/app/posts/register-trainee-teachers/2024-07-30-using-hesa-to-submit-trainee-records-for-2024-to-2025.md
@@ -1,7 +1,7 @@
 ---
-  title:        Using HESA to submit trainee records for 2024 to 2025
-  description:  How lead partners and accredited providers will use HESA to submit trainee records in the 2024 to 2025 academic year
-  date:         2024-07-30
+  title: Using HESA to submit trainee records for 2024 to 2025
+  description: How lead partners and accredited providers will use HESA to submit trainee records in the 2024 to 2025 academic year
+  date: 2024-07-30
   tags:
     - ITT reform
     - providers


### PR DESCRIPTION
How lead partners and accredited providers will use HESA to submit trainee records in the 2024 to 2025 academic year.