### PR TITLE
Set pretty_urls to true in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -59,3 +59,6 @@ force = true
 [build]
 command = "npm run build"
 publish = "public"
+
+[build.processing.html]
+pretty_urls = true


### PR DESCRIPTION
Problem: Images fail to load in the post if URLs do not have a trailing slash
Solution: Set `pretty_urls = true` in the `netlify.toml` configuration file

```
[build.processing.html]
pretty_urls = true
```

This fixes issue #989 

Hat tip @ollietreend 