### PR TITLE
Update ICO URL for 'Public task'

### DIFF
--- a/app/posts/claim-funding-for-mentors/2024-10-08-how-we-use-cookies.md
+++ b/app/posts/claim-funding-for-mentors/2024-10-08-how-we-use-cookies.md
@@ -14,7 +14,7 @@ related:
     - text: DfE Analytics GitHub repository
       href: https://github.com/DFE-Digital/dfe-analytics
     - text: Information Commissioner’s Office - Lawful basis for processing public data
-      href: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/lawful-basis-for-processing/public-task/
+      href: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/public-task/
     - text: Claim funding for mentor training cookies page
       href: https://claim-funding-for-mentor-training.education.gov.uk/cookies
 # screenshots:

--- a/app/posts/claim-funding-for-mentors/2024-10-08-how-we-use-cookies.md
+++ b/app/posts/claim-funding-for-mentors/2024-10-08-how-we-use-cookies.md
@@ -33,4 +33,4 @@ The [DfE Analytics gem](https://github.com/DFE-Digital/dfe-analytics) is a custo
 
 The General Data Protection Regulations (GDPR) require opt-in for cookies. However, server-side tracking (as used by DfE analytics) works by logging requests, user actions, or metadata directly from the server without needing Cookies stored in the user’s browser.
 
-The analytics we use are backend, and most of [the data we collect is for a Public Task](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/lawful-basis-for-processing/public-task/), which means we use the data in Google BigQuery for reporting and improving public services, funding, etc. Users cannot opt out of data used for a Public Task.
+The analytics we use are backend, and most of [the data we collect is for a Public Task](https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/public-task/), which means we use the data in Google BigQuery for reporting and improving public services, funding, etc. Users cannot opt out of data used for a Public Task.


### PR DESCRIPTION
See this post: https://deploy-preview-1395--bat-design-history.netlify.app/claim-funding-for-mentors/how-we-use-cookies/

The ICO URL documenting 'Publis task' has changed from:
```
https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/lawful-basis-for-processing/public-task/
```
To:
```
https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis/public-task/
```
