### PR TITLE
Add post: Correcting the ‘Rest of England’ hourly funding rate

### DIFF
--- a/app/posts/claim-funding-for-mentors/2024-07-31-correcting-the-rest-of-england-hourly-funding-rate.md
+++ b/app/posts/claim-funding-for-mentors/2024-07-31-correcting-the-rest-of-england-hourly-funding-rate.md
@@ -1,0 +1,28 @@
+---
+title: Correcting the ‘Rest of England’ hourly funding rate
+description: We found an error in the funding rate that we needed to fix before we sent claims to the ESFA for payment
+date: 2024-07-31
+tags:
+  - funding
+  - claims
+related:
+  items:
+    - text: Submitting claims for funding
+      href: /claim-funding-for-mentors/submitting-claims-for-funding/
+    - text: Adding the funding calculation to the claim details
+      href: /claim-funding-for-mentors/adding-the-funding-calculation-to-the-claim-details/
+---
+
+The funding rate for schools classified as ‘outside London (the rest of England)’ is £43.80 per hour.
+
+However, when schools in this funding band submitted claims between 2nd May and 19th July, the hourly rate shown in the service was £43.18. This mistake was due to a keying error in the prototype, which carried over to the live Claim funding for mentor training service.
+
+Fortunately, a user alerted us to the error.
+
+## How we fixed this
+
+We corrected the funding rate in the live service to rectify this. This correction updated the value of the impacted claims, and the total amount claimed increased by £3,318.86.
+
+We informed the 148 impacted organisations that had already claimed via email and updated their claim values.
+
+To avoid errors like this in the future, we will implement an updated review checklist that requires the signoff of crucial information, including funding rates and claim windows.


### PR DESCRIPTION
See post: https://deploy-preview-1397--bat-design-history.netlify.app/claim-funding-for-mentors/correcting-the-rest-of-england-hourly-funding-rate/