### PR TITLE
Fix post breadcrumbs

### DIFF
--- a/app/posts/manage-teacher-training-applications/2021-01-18-managing-individual-email-notifications.md
+++ b/app/posts/manage-teacher-training-applications/2021-01-18-managing-individual-email-notifications.md
@@ -2,17 +2,18 @@
 title: Managing individual email notifications
 description: Let users choose which emails they receive
 date: 2021-01-18
-screenshots:
-  items:
-    - account page
-    - settings
-    - success banner
-    - notifications
+tags:
+  - notifications
 related:
   items:
     - text: Content for the end of each email
       href: https://docs.google.com/document/d/1FOT_jBRlMRLjcbyw_sz6IygwCNZkaBp__oRBRBEkn-Y/edit#heading=h.7yben527pu0m
       description: A document showing the content that will appear at the bottom of each email notification
+screenshots:
+  items:
+    - Account page
+    - Email notifications settings page
+    - Success banner
 eleventyComputed:
   eleventyNavigation:
     key: manage-managing-individual-email-notifications

--- a/app/posts/manage-teacher-training-applications/2021-01-18-managing-individual-email-notifications.md
+++ b/app/posts/manage-teacher-training-applications/2021-01-18-managing-individual-email-notifications.md
@@ -4,14 +4,18 @@ description: Let users choose which emails they receive
 date: 2021-01-18
 screenshots:
   items:
-    - Account page
-    - Email notifications settings page
-    - Success banner
+    - account page
+    - settings
+    - success banner
+    - notifications
 related:
   items:
     - text: Content for the end of each email
       href: https://docs.google.com/document/d/1FOT_jBRlMRLjcbyw_sz6IygwCNZkaBp__oRBRBEkn-Y/edit#heading=h.7yben527pu0m
       description: A document showing the content that will appear at the bottom of each email notification
+eleventyComputed:
+  eleventyNavigation:
+    key: manage-managing-individual-email-notifications
 ---
 
 Currently users can [turn off all email notifications](/manage-teacher-training-applications/turn-email-notifications-on-off/). But we know users want to specify which emails they receive.

--- a/app/posts/publish-teacher-training-courses/2022-03-17-managing-individual-email-notifications.md
+++ b/app/posts/publish-teacher-training-courses/2022-03-17-managing-individual-email-notifications.md
@@ -31,6 +31,9 @@ screenshots:
       src: change-email-notifications--multiple-organisations-lead-school.png
     - text: Change your email notifications - multiple organisations (accredited body)
       src: change-email-notifications--multiple-organisations-accredited-body.png
+eleventyComputed:
+  eleventyNavigation:
+    key: publish-managing-individual-email-notifications
 ---
 
 Currently, only users in accredited bodies receive email notifications for courses run by their training providers.


### PR DESCRIPTION
When posts have the same URL slug, we get a weird situation where the breadcrumbs show all the service names where the duplication has occurred.

This PR fixes duplicate breadcrumbs on:

- [Managing individual email notifications](https://deploy-preview-1445--bat-design-history.netlify.app/manage-teacher-training-applications/managing-individual-email-notifications/) - Manage teacher training applications
- [Managing individual email notifications](https://deploy-preview-1445--bat-design-history.netlify.app/publish-teacher-training-courses/managing-individual-email-notifications/) - Publish teacher training courses 