### PR TITLE
Fix table alignment

### DIFF
--- a/app/assets/styles/_tables.scss
+++ b/app/assets/styles/_tables.scss
@@ -1,0 +1,16 @@
+.app-table {
+  .app-table__cell,
+  .app-table__header {
+    &--align-left{
+      text-align: left;
+    }
+
+    &--align-center {
+      text-align: center;
+    }
+
+    &--align-right {
+      text-align: right;
+    }
+  }
+}

--- a/app/assets/styles/application.scss
+++ b/app/assets/styles/application.scss
@@ -12,6 +12,7 @@ $govuk-global-styles: true;
 // Becoming a teacher design history styles
 @import "bat-design-history";
 @import "markdown";
+@import "tables";
 
 .app-prose .app-images--two-thirds-width img {
   max-width: 66.6%;

--- a/lib/libraries/markdown.js
+++ b/lib/libraries/markdown.js
@@ -11,6 +11,42 @@ module.exports = (() => {
 
   const parser = markdown(opts)
 
+  // Define class-based alignment handling for tables
+  const alignments = ['left', 'center', 'right']
+
+  // Override the `table_open` rule to add a class to the table
+  parser.renderer.rules.table_open = (tokens, idx, options, env) => {
+    tokens[idx].attrPush(['class', 'app-table']) // Add your custom class
+    return parser.renderer.renderToken(tokens, idx, options)
+  }
+
+  // Override `td_open` to handle alignment classes
+  parser.renderer.rules.td_open = (tokens, idx, options, env) => {
+    const token = tokens[idx]
+    const align = token.attrGet('style')?.match(/text-align:(left|center|right)/)?.[1]
+    if (align && alignments.includes(align)) {
+      token.attrPush(['class', `app-table__cell app-table__cell--align-${align}`])
+      token.attrs = token.attrs.filter(attr => attr[0] !== 'style') // Remove inline style
+    }
+    return `<td${renderAttrs(token)}>`
+  }
+
+  // Override `th_open` to handle alignment classes
+  parser.renderer.rules.th_open = (tokens, idx, options, env) => {
+    const token = tokens[idx]
+    const align = token.attrGet('style')?.match(/text-align:(left|center|right)/)?.[1]
+    if (align && alignments.includes(align)) {
+      token.attrPush(['class', `app-table__header app-table__header--align-${align}`])
+      token.attrs = token.attrs.filter(attr => attr[0] !== 'style') // Remove inline style
+    }
+    return `<th${renderAttrs(token)}>`
+  }
+
+  // Helper function to render attributes
+  const renderAttrs = (token) => {
+    return token.attrs ? ' ' + token.attrs.map(attr => `${attr[0]}="${attr[1]}"`).join(' ') : ''
+  }
+
   parser
     .use(require('markdown-it-abbr'))
     .use(anchor, {


### PR DESCRIPTION
This PR fixes table alignment.

The problem: the content security policy prevents inline styles.

Possible solutions:

- update the CSP to include hashes for inline styles
- update the markdown parser to apply table alignment classes

We decided to update the markdown parser as this is more robust.