### PR TITLE
Fix related links

### DIFF
--- a/app/posts/register-of-training-providers/2025-01-27-defining-the-attributes-of-teacher-training-providers.md
+++ b/app/posts/register-of-training-providers/2025-01-27-defining-the-attributes-of-teacher-training-providers.md
@@ -8,7 +8,7 @@ tags:
 related:
   items:
     - text: Understanding the relationships between organisations delivering initial teacher training
-      href: /understanding-the-relationships-between-organisations-delivering-initial-teacher-training/
+      href: /becoming-a-teacher/understanding-the-relationships-between-organisations-delivering-initial-teacher-training/
 ---
 
 Training providers in initial teacher training (ITT) can take various forms, including:
@@ -16,7 +16,7 @@ Training providers in initial teacher training (ITT) can take various forms, inc
 - accredited ITT providers
 - training partners - also known as lead partners
 
-You can read more about these relationships in an earlier post on [understanding provider relationships](/understanding-the-relationships-between-organisations-delivering-initial-teacher-training/).
+You can read more about these relationships in an earlier post on [understanding provider relationships](/becoming-a-teacher/understanding-the-relationships-between-organisations-delivering-initial-teacher-training/).
 
 Below is an overview of the attributes we use to identify and manage initial teacher training providers.
 

--- a/app/posts/register-of-training-providers/2025-02-04-adding-providers-to-the-register.md
+++ b/app/posts/register-of-training-providers/2025-02-04-adding-providers-to-the-register.md
@@ -8,8 +8,8 @@ tags:
   - training partners
 related:
   items:
-    - text: The attributes of a training provider
-      href: /register-of-training-providers/the-attributes-of-a-training-provider/
+    - text: Defining the attributes of teacher training providers
+      href: /register-of-training-providers/defining-the-attributes-of-teacher-training-providers/
     - text: Changing provider details
       href: /register-of-training-providers/changing-provider-details/
     - text: Managing provider accreditations

--- a/app/posts/register-of-training-providers/2025-02-05-changing-provider-details.md
+++ b/app/posts/register-of-training-providers/2025-02-05-changing-provider-details.md
@@ -8,8 +8,8 @@ tags:
   - training partners
 related:
   items:
-    - text: The attributes of a training provider
-      href: /register-of-training-providers/the-attributes-of-a-training-provider/
+    - text: Defining the attributes of teacher training providers
+      href: /register-of-training-providers/defining-the-attributes-of-teacher-training-providers/
     - text: Adding providers to the register
       href: /register-of-training-providers/adding-providers-to-the-register/
     - text: Managing provider accreditations

--- a/app/posts/register-of-training-providers/2025-02-06-managing-provider-addresses.md
+++ b/app/posts/register-of-training-providers/2025-02-06-managing-provider-addresses.md
@@ -8,8 +8,8 @@ tags:
   - locations
 related:
   items:
-    - text: The attributes of a training provider
-      href: /register-of-training-providers/the-attributes-of-a-training-provider/
+    - text: Defining the attributes of teacher training providers
+      href: /register-of-training-providers/defining-the-attributes-of-teacher-training-providers/
     - text: Adding providers to the register
       href: /register-of-training-providers/adding-providers-to-the-register/
     - text: Changing provider details

--- a/app/posts/register-of-training-providers/2025-02-07-managing-provider-accreditations.md
+++ b/app/posts/register-of-training-providers/2025-02-07-managing-provider-accreditations.md
@@ -8,8 +8,8 @@ tags:
   - accreditation
 related:
   items:
-    - text: The attributes of a training provider
-      href: /register-of-training-providers/the-attributes-of-a-training-provider/
+    - text: Defining the attributes of teacher training providers
+      href: /register-of-training-providers/defining-the-attributes-of-teacher-training-providers/
     - text: Adding providers to the register
       href: /register-of-training-providers/adding-providers-to-the-register/
     - text: Changing provider details

--- a/app/posts/register-of-training-providers/2025-02-08-managing-provider-contacts.md
+++ b/app/posts/register-of-training-providers/2025-02-08-managing-provider-contacts.md
@@ -7,8 +7,8 @@ tags:
   - contact details
 related:
   items:
-    - text: The attributes of a training provider
-      href: /register-of-training-providers/the-attributes-of-a-training-provider/
+    - text: Defining the attributes of teacher training providers
+      href: /register-of-training-providers/defining-the-attributes-of-teacher-training-providers/
     - text: Adding providers to the register
       href: /register-of-training-providers/adding-providers-to-the-register/
     - text: Changing provider details

--- a/app/posts/register-of-training-providers/2025-02-12-managing-provider-partnerships.md
+++ b/app/posts/register-of-training-providers/2025-02-12-managing-provider-partnerships.md
@@ -8,8 +8,8 @@ tags:
   - partnerships
 related:
   items:
-    - text: The attributes of a training provider
-      href: /register-of-training-providers/the-attributes-of-a-training-provider/
+    - text: Defining the attributes of teacher training providers
+      href: /register-of-training-providers/defining-the-attributes-of-teacher-training-providers/
     - text: Adding providers to the register
       href: /register-of-training-providers/adding-providers-to-the-register/
     - text: Changing provider details


### PR DESCRIPTION
This PR fixes an error with a related link.

From this:

```
- text: The attributes of a training provider
  href: /register-of-training-providers/the-attributes-of-a-training-provider/
```

To this:

```
- text: Defining the attributes of teacher training providers
  href: /register-of-training-providers/defining-the-attributes-of-teacher-training-providers/
```

Affected posts:

- [Managing provider partnerships](https://deploy-preview-1523--bat-design-history.netlify.app/register-of-training-providers/managing-provider-partnerships/)
- [Managing provider contacts](https://deploy-preview-1523--bat-design-history.netlify.app/register-of-training-providers/managing-provider-contacts/)
- [Managing provider accreditations](https://deploy-preview-1523--bat-design-history.netlify.app/register-of-training-providers/managing-provider-accreditations/)
- [Managing provider addresses](https://deploy-preview-1523--bat-design-history.netlify.app/register-of-training-providers/managing-provider-addresses/)
- [Changing provider details](https://deploy-preview-1523--bat-design-history.netlify.app/register-of-training-providers/changing-provider-details/)
- [Adding providers to the register](https://deploy-preview-1523--bat-design-history.netlify.app/register-of-training-providers/adding-providers-to-the-register/)