### PR TITLE
Add post: Updating CSV error format

### DIFF
--- a/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
+++ b/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
@@ -1,5 +1,4 @@
 ---
-
 title: Updating CSV error format
 description: Details of how and why we updated the CSV Bulk add trainees error format
 date: 2025-03-31
@@ -7,36 +6,36 @@ tags:
   - trainees
   - providers
   - CSV
-
 ---
-User research revealed that the current structure of the error column for the 'CSV bulk add new trainees' tool is somewhat difficult to read and hard to use when processing many errors.  In addition, some users found it confusing that no message as given for trainees' records that passed all validations and had no errors.  
+
+User research revealed that the current structure of the error column for the ‘CSV bulk add new trainees’ tool is somewhat difficult to read and use when processing many errors. In addition, some users found it confusing that no message was given for trainees’ records that passed all validations and had no errors.
 
 ## What we have changed
 
 Instead of a single error column being include in the validation results file, two are now include:
 
-* **Validation results** stating the high-level result of the validation: passed or X errors found.
+- **Validation results** stating the high-level result of the validation: passed or X errors found.
 
-* **Errors**, listing all errors found. Delineated by both a semi-colon and line break.
+- **Errors**, listing all errors found. Delineated by both a semi-colon and line break.
 
-See new error structure in this table:
+See the new error structure in this table:
 
-Validation results | Errors
-----|----
-3 errors found | Itt start date is invalid; <BR> Degrees attributes Subject can't be blank; <BR> Degrees attributes Grade can't be blank
-1 error found | Itt start date is invalid
-Validation passed | ----
+| Validation results | Errors |
+| ---- | ---- |
+| 3 errors found | Itt start date is invalid; <br> Degrees attributes Subject can't be blank; <br> Degrees attributes Grade can't be blank |
+| 1 error found | Itt start date is invalid |
+| Validation passed | ---- |
 
 ## Reasons for our approach
 
-By splitting the results in addition to adding line break delineation between errors we have make the results of validation:
+By splitting the results in addition to adding line break delineation between errors, we have made the results of validation:
 
-* Easier to sort and filter
-* Clearer when trainee records have passed validation
-* Quicker to scan for specific errors
+- easier to sort and filter
+- clearer when trainee records have passed validation
+- quicker to scan for specific errors
 
 ## Next steps
 
-Having implemented these changes our next step is to test them with providers, first with moderated usability testing, then unmoderated sandbox testing.
+Having implemented these changes, our next step is to test them with providers, first with moderated usability testing and then unmoderated sandbox testing.
 
 *[CSV]: comma-separated values

--- a/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
+++ b/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
@@ -20,7 +20,7 @@ Instead of a single error column being include in the validation results file, t
 
 See the new error structure in this table:
 
-| Validation results | Errors |
+| Validation results | Example errors |
 | ---- | ---- |
 | 3 errors found | Itt start date is invalid; <br> Degrees attributes Subject can't be blank; <br> Degrees attributes Grade can't be blank |
 | 1 error found | Itt start date is invalid |

--- a/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
+++ b/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
@@ -25,7 +25,7 @@ Validation results | Errors
 ----|----
 3 errors found | Itt start date is invalid; <BR> Degrees attributes Subject can't be blank; <BR> Degrees attributes Grade can't be blank
 1 error found | Itt start date is invalid
-Validation passed |
+Validation passed | ----
 
 ## Reasons for our approach
 

--- a/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
+++ b/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
@@ -1,0 +1,44 @@
+---
+
+title: Updating CSV error format
+description: Details of how and why we updated the CSV Bulk add trainees error format
+date: 2025-03-31
+tags:
+  - trainees
+  - providers
+  - CSV
+
+---
+User research revealed that the current structure of the error column for the 'CSV bulk add new trainees' tool is somewhat difficult to read and hard to use when processing many errors.  In addition, some users found it confusing that no message as given for trainees' records that passed all validations and had no errors.  
+
+## What we have changed 
+
+Instead of a single error column being include in the validation results file, two are now include: 
+
+* **Validation results** stating the high-level result of the validation: passed or X errors found. 
+
+* **Errors**, listing all errors found. Delineated by both a semi-colon and line break. 
+
+See new error structure in this table: 
+
+ 
+
+Validation results | Errors 
+----|----
+3 errors found | Itt start date is invalid; <BR> Degrees attributes Subject can't be blank; <BR> Degrees attributes Grade can't be blank 
+1 error found | Itt start date is invalid 
+Validation passed |   
+
+## Reasons for our approach 
+
+By splitting the results in addition to adding line break delineation between errors we have make the results of validation: 
+
+* Easier to sort and filter 
+* Clearer when trainee records have passed validation 
+* Quicker to scan for specific errors 
+
+## Next steps 
+
+Having implemented these changes our next step is to test them with providers, first with moderated usability testing, then unmoderated sandbox testing. 
+
+*[CSV]: comma-separated values

--- a/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
+++ b/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
@@ -11,34 +11,32 @@ tags:
 ---
 User research revealed that the current structure of the error column for the 'CSV bulk add new trainees' tool is somewhat difficult to read and hard to use when processing many errors.  In addition, some users found it confusing that no message as given for trainees' records that passed all validations and had no errors.  
 
-## What we have changed 
+## What we have changed
 
-Instead of a single error column being include in the validation results file, two are now include: 
+Instead of a single error column being include in the validation results file, two are now include:
 
-* **Validation results** stating the high-level result of the validation: passed or X errors found. 
+* **Validation results** stating the high-level result of the validation: passed or X errors found.
 
-* **Errors**, listing all errors found. Delineated by both a semi-colon and line break. 
+* **Errors**, listing all errors found. Delineated by both a semi-colon and line break.
 
-See new error structure in this table: 
+See new error structure in this table:
 
- 
-
-Validation results | Errors 
+Validation results | Errors
 ----|----
-3 errors found | Itt start date is invalid; <BR> Degrees attributes Subject can't be blank; <BR> Degrees attributes Grade can't be blank 
-1 error found | Itt start date is invalid 
-Validation passed |   
+3 errors found | Itt start date is invalid; <BR> Degrees attributes Subject can't be blank; <BR> Degrees attributes Grade can't be blank
+1 error found | Itt start date is invalid
+Validation passed |
 
-## Reasons for our approach 
+## Reasons for our approach
 
-By splitting the results in addition to adding line break delineation between errors we have make the results of validation: 
+By splitting the results in addition to adding line break delineation between errors we have make the results of validation:
 
-* Easier to sort and filter 
-* Clearer when trainee records have passed validation 
-* Quicker to scan for specific errors 
+* Easier to sort and filter
+* Clearer when trainee records have passed validation
+* Quicker to scan for specific errors
 
-## Next steps 
+## Next steps
 
-Having implemented these changes our next step is to test them with providers, first with moderated usability testing, then unmoderated sandbox testing. 
+Having implemented these changes our next step is to test them with providers, first with moderated usability testing, then unmoderated sandbox testing.
 
 *[CSV]: comma-separated values

--- a/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
+++ b/app/posts/register-trainee-teachers/2025-03-31-update-csv-error-format.md
@@ -24,7 +24,7 @@ See the new error structure in this table:
 | ---- | ---- |
 | 3 errors found | Itt start date is invalid; <br> Degrees attributes Subject can't be blank; <br> Degrees attributes Grade can't be blank |
 | 1 error found | Itt start date is invalid |
-| Validation passed | ---- |
+| Validation passed | - |
 
 ## Reasons for our approach
 


### PR DESCRIPTION
Added design history on changing the format used for reporting back errors in CSV file upload for the bulk add new trainees tool.

Post URL: [Updating CSV error format](https://deploy-preview-1538--bat-design-history.netlify.app/register-trainee-teachers/update-csv-error-format/)