### PR TITLE
Miscellaneous updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# Design history for becoming a teacher
+# Design history for Becoming a teacher (BAT)
 
-https://becoming-a-teacher.design-history.education.gov.uk/
+A history of the product, design, technology and policy decisions shaping the services that enable and support trainee teacher recruitment.
+
+<https://becoming-a-teacher.design-history.education.gov.uk/>
 
 ## Purpose of this project
 
 This repository makes it easy to:
 
-- screenshot your designs
-- create pages of screenshots to document designs
 - document designs using the [GOV.UK Design System](https://design-system.service.gov.uk/)
 - print pages of designs
 - make designs shareable and linkable
@@ -38,5 +38,5 @@ The design history uses the [GOV.UK Design System](https://design-system.service
 
 This design history replaces an earlier version based on the govuk-prototype-kit:
 
-- https://github.com/DFE-Digital/bat-design-history-old
-- https://bat-design-history-old.herokuapp.com/
+- <https://github.com/DFE-Digital/bat-design-history-old>
+- <https://bat-design-history-old.herokuapp.com/>

--- a/app/_layouts/base.njk
+++ b/app/_layouts/base.njk
@@ -68,7 +68,10 @@
     meta: {
       items: [{
         text: "Get Into Teaching design history",
-        href: "https://git-design-history.netlify.app"
+        href: "https://design-histories.education.gov.uk/get-into-teaching"
+      }, {
+        text: "Get School Experience design history",
+        href: "https://design-histories.education.gov.uk/get-school-experience"
       }, {
         text: "GitHub",
         href: "https://github.com/dfe-digital/bat-design-history"

--- a/app/glossary.md
+++ b/app/glossary.md
@@ -10,5 +10,4 @@ eleventyComputed:
     parent: home
 ---
 
-The glossary and style guide has moved:
-[https://dfe-glossary.herokuapp.com/](https://design.education.gov.uk/content-design/style-guide/)
+The glossary and style guide has moved: <https://design.education.gov.uk/content-design/style-guide>

--- a/app/posts/find-teacher-training/2025-04-07-user-research-with-candidates-on-showing-provider-data-round-2.md
+++ b/app/posts/find-teacher-training/2025-04-07-user-research-with-candidates-on-showing-provider-data-round-2.md
@@ -10,32 +10,32 @@ tags:
 related:
   items:
     - text: User research with candidates on showing provider data
-      href: https://becoming-a-teacher.design-history.education.gov.uk/find-teacher-training/user-research-with-candidates-on-showing-provider-data/
+      href: /find-teacher-training/user-research-with-candidates-on-showing-provider-data/
 ---
 
-This is the second round of user research aimed at understanding what additional information candidates would find helpful about provider performance and how they would use it when deciding on a course.  
+This is the second round of user research aimed at understanding what additional information candidates would find helpful about provider performance and how they would use it when deciding on a course.
 
-The first round of research is published [here](https://becoming-a-teacher.design-history.education.gov.uk/find-teacher-training/user-research-with-candidates-on-showing-provider-data/).
+[View the first round of research](/user-research-with-candidates-on-showing-provider-data/).
 
 ## Background of the research
 
 The Find and Publish team needs to be confident in changes made to displaying provider performance data before this can be presented to providers.
 
-This round of research will focus on reducing the additional information displayed in the designs on Find service based on the recommendations from the [first round of research]( https://becoming-a-teacher.design-history.education.gov.uk/find-teacher-training/user-research-with-candidates-on-showing-provider-data/).  
+This round of research will focus on reducing the additional information displayed in the designs on Find service based on the recommendations from the [first round of research](/find-teacher-training/user-research-with-candidates-on-showing-provider-data/).
 
 ## Objectives
 
-- To determine if there is a clear consensus from candidates on the usefulness of additional provider data and its use in finding appropriate courses to apply for  
+- To determine if there is a clear consensus from candidates on the usefulness of additional provider data and its use in finding appropriate courses to apply for
 - To identify and measure the impact that the success rate and response time has on candidates’ decision to apply for teacher training courses
 
 ## What we tested
 
 This research aims to gather candidate feedback on provider performance data presented within the Find Teacher Training Course service.
 
-The specific data tested included:  
+The specific data tested included:
 
-- Qualified teacher status (QTS) success rate  
-- Provider response time to applications  
+- Qualified teacher status (QTS) success rate
+- Provider response time to applications
 
 ## Participants
 
@@ -70,7 +70,7 @@ Participants compared courses using various criteria including:
 
 Additionally, participants reported that they would use league tables and [Ofsted reports](https://reports.ofsted.gov.uk/) to identify potential red flags and challenging schools.
 
-## Feedback on QTS success rate  
+## Feedback on QTS success rate
 
 Participants consistently highlighted the importance of success rate data when selecting teacher training courses.
 
@@ -106,7 +106,7 @@ Displaying success rate data from a previous year was suggested as a better alte
 
 #### Accordion usage
 
-Success rate average data was found helpful when accessed via the accordion component.  
+Success rate average data was found helpful when accessed via the accordion component.
 
 ### Implications for design
 

--- a/app/posts/how-to/2024-01-16-what-to-include-in-a-design-history-post.md
+++ b/app/posts/how-to/2024-01-16-what-to-include-in-a-design-history-post.md
@@ -41,4 +41,4 @@ Your users’ primary needs will be to simply and quickly understand how you pre
 
 - write the most straightforward and shortest post you can
 - use headings and bullet points to aid reading
-- follow the [GOV.UK style guide](https://www.gov.uk/guidance/style-guide/a-to-z) and the [DfE style guide](https://design.education.gov.uk/design-system/style-guide)
+- follow the [GOV.UK style guide](https://www.gov.uk/guidance/style-guide/a-to-z) and the [DfE style guide](https://design.education.gov.uk/content-design/style-guide)


### PR DESCRIPTION
This PR:

- Fixes the broken Get information teaching design history link in the footer
- Adds the 'Get school experience' design history to the footer
- Fixes the DfE style guide link
- Adds a description to the `readme.md`
- Removes the BAT DH URL from links - we favour relative URLs in the design history and absolute URLs for external links