### PR TITLE
updating tenses and dates now that this work is live

### DIFF
--- a/app/posts/apply-for-teacher-training/2025-05-23-set-a-different-deadline-for-visa-sponsored-applications.md
+++ b/app/posts/apply-for-teacher-training/2025-05-23-set-a-different-deadline-for-visa-sponsored-applications.md
@@ -1,7 +1,7 @@
 ---
 title: Set a different deadline for candidates who need visa sponsorship
 description: Helping candidates to apply in good time so they can start their course on time.
-date: 2024-10-15
+date: 2025-05-23
 tags:
   - international
   - visa sponsorship
@@ -19,11 +19,9 @@ The training provider does additional checks on international applications, for 
 
 Some candidates who require a visa are applying too late in the cycle for these checks to take place before the course starts.
 
-## What we plan to do
+## What we have done
 
-**None of these changes have been pushed live into the services at this time.**
-
-We will add a question to the Publish journey to ask providers who have said that they can sponsor visas whether they would like to close their course to candidates who need a visa before the course closing date.  
+We have added a question to the Publish journey to ask providers who have said that they can sponsor visas whether they would like to close their course to candidates who need a visa before the course closing date.  
 
 The training provider can select any date to close the course to candidates who need a visa.  
 
@@ -36,6 +34,8 @@ If they have applied to more than one course they will see a banner warning for 
 There will also be a warning banner on each application.
 
 When the deadline has passed without the candidate submitting their application, they will see a note telling them what has happened and directing them to search for another course.
+
+These changes went live on 13 May 2025.
 
 ## Research with candidates and training providers
 


### PR DESCRIPTION
We had previously published a design history for this work, but we had not published the work itself. Now that we have I've updated the dates on the post and the tense of the content to make it clear that these changes are live and not proposed for future readers to know what's what