### PR TITLE
Add post: Why the Register of training providers is not a transactional service

### DIFF
--- a/app/posts/register-of-training-providers/2025-06-11-why-the-register-of-training-providers-is-not-a-transactional-service.md
+++ b/app/posts/register-of-training-providers/2025-06-11-why-the-register-of-training-providers-is-not-a-transactional-service.md
@@ -1,0 +1,87 @@
+---
+title: Why the Register of training providers is not a transactional service
+description: The service is a source of truth, a shared record, and a foundation for other services
+date: 2025-06-11
+tags:
+  - transactions
+  - services
+related:
+  items:
+    - text: Getting the scope of your transaction right
+      description: GOV.UK Service manual - design
+      href: https://www.gov.uk/service-manual/design/scoping-your-service
+    - text: Designing how GOV.UK content and transactions work together
+      description: GOV.UK Service manual - design
+      href: https://www.gov.uk/service-manual/design/govuk-content-transactions
+    - text: Check if you need to meet the Service Standard or get an assessment
+      description: GOV.UK Service manual - service assessments
+      href: https://www.gov.uk/service-manual/service-assessments/check-if-need-to-meet-service-standard
+---
+
+We are often asked whether the Register of training providers (Register) is a transactional service. In this post, we explain why it is not, using GOV.UK guidance on service classification. We also describe what the Register is - a source of truth, a shared record, and a foundation for other services.
+
+## What counts as a transactional service on GOV.UK
+
+According to GOV.UK guidance, a service is transactional if it allows users to either:
+
+- exchange information, money, permission, goods or services
+- submit personal information that results in a change to a government record
+
+Services are measured in terms of completed transactions.
+
+Examples of transactional services include:
+
+- Apply for a driving licence
+- Pay your self-assessment tax bill
+- Apply for a student loan
+
+These services share certain traits:
+
+- A clear start and end point
+- A user who needs to do something
+- A government decision or outcome
+- A measurable transaction (submit, apply, pay, register)
+
+## What the Register does instead
+
+The Register of training providers does not involve a user completing a transaction with government. It is:
+
+- a canonical list of teacher training providers
+- a shared record used by multiple services, teams and users
+- a structured dataset with accurate, up-to-date provider information
+
+No single user ‘completes’ an interaction with the Register in a linear way. Instead, users view, update or use information in the Register for other purposes:
+
+- policy and compliance teams use the data to regulate accreditation
+- service teams use the data to power course publishing and application journeys
+- providers check and manage their details over time, but not as a single task
+
+In that sense, the Register is not a transactional service. It is more like:
+
+- a data and information service
+- an administrative interface for managing structured records
+- a reference point for other transactional services, like Publish teacher training courses, Apply for teacher training or Register trainee teachers
+
+## Why this distinction matters
+
+Understanding that the Register is not a transactional service has shaped our approach in several ways:
+
+- Design and navigation: We do not expect users to complete a single journey. Instead, we support discovery, updating and collaboration over time.
+
+- Service scope and measures: We do not measure success by the number of transactions completed, but rather by data quality, ease of use, and uptake by other services.
+
+- Service ownership: The Register serves internal and external users across several touchpoints. It is part of a wider service ecosystem, not a standalone end-user journey.
+
+## What we considered
+
+We examined closely whether specific actions in the Register could be considered transactions. For example, updating provider details or requesting a change to accreditation. But:
+
+- these actions do not result in an immediate outcome for the user
+- many changes go through internal workflows, approvals or reviews
+- providers and DfE users interact with the Register repeatedly, not in one-off sessions
+
+This confirmed our position that the Register supports, but does not itself deliver, transactional outcomes.
+
+## Conclusion
+
+The Register of training providers is not a transactional service. It is a shared record, data source and coordination point for other services. By recognising this, we can design more effectively for the real users and relationships involved.


### PR DESCRIPTION
Post URL: https://deploy-preview-1636--bat-design-history.netlify.app/register-of-training-providers/why-the-register-of-training-providers-is-not-a-transactional-service/