### PR TITLE
Add post: Releasing the first slice of the Register of training providers

### DIFF
--- a/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
+++ b/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
@@ -7,7 +7,7 @@ tags:
   - iteration
 ---
 
-In mid-August 2025, we released the first working slice of the Register of training providers to internal users and stakeholders.
+In mid-August 2025, we released the first working slice of the [Register of training providers](https://register-of-training-providers.education.gov.uk/) to internal users and stakeholders.
 
 This release was not a full service, but a minimum set of features that demonstrated how key parts of the register would work together.
 

--- a/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
+++ b/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
@@ -5,6 +5,7 @@ date: 2025-09-01
 tags:
   - register
   - iteration
+  - mvp
 ---
 
 In mid-August 2025, we released the first working slice of the [Register of training providers](https://register-of-training-providers.education.gov.uk/) to internal users and stakeholders.
@@ -26,6 +27,24 @@ The first slice included:
 
 This set of features focused on the foundations: who can access the system, how we manage users, and how provider records are created, changed and found.
 
+## Delivery principles and practices
+
+We followed two core delivery principles throughout this work:
+
+- Release early, release often - we aimed to ship a working product as early as possible, then improve it through frequent, incremental releases
+
+- Test with real users - we prioritised building something users could interact with, rather than reviewing static designs or documentation
+
+To support these principles, we used the following delivery practices:
+
+- Minimum Viable Product (MVP) - we focused only on essential features to demonstrate the service could function end-to-end
+
+- Thin vertical slices - we released a small but complete workflow, rather than building isolated components
+
+- Working software over documentation - our goal was to learn from interaction, not description
+
+These practices helped us avoid over-investing in unproven assumptions and instead build confidence through working code and real feedback.
+
 ## Why we released early
 
 We wanted to test the value of the register with real users and stakeholders as early as possible. Releasing a small, working slice gives us several advantages, including:
@@ -37,7 +56,7 @@ We wanted to test the value of the register with real users and stakeholders as 
 
 ## Benefits of this approach
 
-Releasing early and often is a core principle of agile delivery. It allows us to:
+Early releases are part of how we reduce risk and build better services. It allows us to:
 
 - iterate with purpose - getting feedback from real usage helps us prioritise improvements and identify gaps
 - spot issues early - we can uncover edge cases and usability challenges that we would not have found through design reviews alone

--- a/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
+++ b/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
@@ -56,7 +56,7 @@ We wanted to test the value of the register with real users and stakeholders as 
 
 ## Benefits of this approach
 
-Early releases are part of how we reduce risk and build better services. It allows us to:
+While we work in the open and show work in progress every two weeks, early releases are part of how we reduce risk and build better services. It allows us to:
 
 - iterate with purpose - getting feedback from real usage helps us prioritise improvements and identify gaps
 - spot issues early - we can uncover edge cases and usability challenges that we would not have found through design reviews alone

--- a/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
+++ b/app/posts/register-of-training-providers/2025-09-01-releasing-the-first-slice-of-the-register-of-training-providers.md
@@ -1,0 +1,64 @@
+---
+title: Releasing the first slice of the Register of training providers
+description: In mid-August 2025, we released the first working slice of the register to internal users and stakeholders
+date: 2025-09-01
+tags:
+  - register
+  - iteration
+---
+
+In mid-August 2025, we released the first working slice of the Register of training providers to internal users and stakeholders.
+
+This release was not a full service, but a minimum set of features that demonstrated how key parts of the register would work together.
+
+Releasing this early version enables us to test our assumptions, gather feedback, and build confidence in the direction of the service.
+
+## What we released
+
+The first slice included:
+
+- DfE Sign-in integration - so users could securely log in using an existing DfE account
+- support user management - administrators could add, edit or delete support users
+- a ‘Your account’ page - to view and check account details
+- adding and managing providers - users could add a provider with basic details (legal name, operating name, UKPRN, URN and provider code), and then edit, delete, archive or restore them, with validation built in
+- provider search and filters - users could search, filter and paginate a list of providers
+- static content pages - including the start page, accessibility statement, cookie policy and privacy policy
+
+This set of features focused on the foundations: who can access the system, how we manage users, and how provider records are created, changed and found.
+
+## Why we released early
+
+We wanted to test the value of the register with real users and stakeholders as early as possible. Releasing a small, working slice gives us several advantages, including:
+
+- validating the core user journey, especially around searching for and managing providers
+- getting early feedback from policy and operational teams, helping us shape priorities and clarify assumptions
+- reducing delivery risk by proving we can integrate with DfE Sign-in, manage user accounts, and enforce data validation before building more complex features
+- helping stakeholders gain confidence since they can see and interact with the service, rather than just reviewing slide decks or documents
+
+## Benefits of this approach
+
+Releasing early and often is a core principle of agile delivery. It allows us to:
+
+- iterate with purpose - getting feedback from real usage helps us prioritise improvements and identify gaps
+- spot issues early - we can uncover edge cases and usability challenges that we would not have found through design reviews alone
+- build trust - stakeholders can see progress and understand how their input shaped the service
+
+## Challenges and trade-offs
+
+This approach also comes with some challenges, including:
+
+- incomplete features can confuse users - we needed to clearly explain the purpose of the release and manage expectations around what the service could and could not do
+- additional effort is needed to test and support partial functionality - we needed to monitor usage and triage feedback even for this limited slice
+- stakeholders may expect progress to be faster - early visibility can raise expectations, so we had to communicate clearly about what would come next
+
+## What we hope to learn
+
+By releasing a thin but functional slice, we moved the conversation from theoretical to practical. It helps us surface real questions about how users will interact with the register, and provides us with a better understanding of what different user groups need.
+
+We saw the importance of:
+
+- delivering working software early, even if it is incomplete
+- testing functionality in context, with realistic data
+- being transparent about progress and next steps
+
+This early release provides a solid foundation to build upon and helps steer the direction of future iterations.


### PR DESCRIPTION
Post URL: https://deploy-preview-1733--bat-design-history.netlify.app/register-of-training-providers/releasing-the-first-slice-of-the-register-of-training-providers/