### PR TITLE
Fix eleventyComputed navigation title

### DIFF
--- a/app/posts/claim-funding-for-mentors/2023-12-18-adding-organisations-in-support.md
+++ b/app/posts/claim-funding-for-mentors/2023-12-18-adding-organisations-in-support.md
@@ -32,6 +32,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-funding-support-adding-organisations
+    title: Adding organisations in Support
 ---
 
 We added a way for the support team to onboard new organisations to Claim funding for mentors.

--- a/app/posts/claim-funding-for-mentors/2023-12-18-managing-organisation-users-in-support.md
+++ b/app/posts/claim-funding-for-mentors/2023-12-18-managing-organisation-users-in-support.md
@@ -35,6 +35,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-funding-support-managing-organisation-users
+    title: Managing organisation users in Support
 ---
 
 We added a way for support team users to manage users belonging to an organisation.

--- a/app/posts/claim-funding-for-mentors/2023-12-19-signing-in-to-the-service.md
+++ b/app/posts/claim-funding-for-mentors/2023-12-19-signing-in-to-the-service.md
@@ -45,6 +45,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: funding-mentors-signing-in-to-the-service
+    title: Signing in to the service
 ---
 
 All users must use the Department for Education (DfE) Sign-in to access Claim funding for mentor training.

--- a/app/posts/claim-funding-for-mentors/2024-01-11-adding-a-school-when-javascript-is-unavailable.md
+++ b/app/posts/claim-funding-for-mentors/2024-01-11-adding-a-school-when-javascript-is-unavailable.md
@@ -31,6 +31,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-funding-support-add-school-no-js
+    title: Adding a school when JavaScript is unavailable
 ---
 
 When a support user adds a school in Claim funding for mentors, we use an autocomplete to help users search for schools.

--- a/app/posts/claim-funding-for-mentors/2024-01-12-managing-support-users.md
+++ b/app/posts/claim-funding-for-mentors/2024-01-12-managing-support-users.md
@@ -35,6 +35,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-funding-managing-support-users
+    title: Managing support users
 ---
 
 We added a way for the support team to manage access to Support for Claim funding for mentors (Support).

--- a/app/posts/claim-funding-for-mentors/2024-02-09-adding-mentors.md
+++ b/app/posts/claim-funding-for-mentors/2024-02-09-adding-mentors.md
@@ -39,6 +39,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-mentor-funding-adding-mentors
+    title: Adding mentors
 ---
 
 We added a way for schools to add their mentors to Claim funding for mentors.

--- a/app/posts/claim-funding-for-mentors/2024-02-12-adding-mentors-in-support.md
+++ b/app/posts/claim-funding-for-mentors/2024-02-12-adding-mentors-in-support.md
@@ -39,6 +39,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-mentor-funding-support-adding-organisation-mentors
+    title: Adding mentors in Support
 ---
 
 We added a way for Support users to manage mentors belonging to a school.

--- a/app/posts/claim-funding-for-mentors/2024-03-20-collecting-feedback-about-the-service.md
+++ b/app/posts/claim-funding-for-mentors/2024-03-20-collecting-feedback-about-the-service.md
@@ -23,6 +23,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-funding-collecting-feedback
+    title: Collecting feedback about the service
 ---
 
 > Update: We will collect feedback via a Microsoft form instead of building a form within the service.

--- a/app/posts/claim-funding-for-mentors/2024-04-16-service-error-pages.md
+++ b/app/posts/claim-funding-for-mentors/2024-04-16-service-error-pages.md
@@ -28,6 +28,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: claim-funding-service-error-pages
+    title: Service error pages
 ---
 
 We added the service error pages used when:

--- a/app/posts/claim-funding-for-mentors/2024-04-29-adding-date-of-birth-to-the-add-mentor-flow.md
+++ b/app/posts/claim-funding-for-mentors/2024-04-29-adding-date-of-birth-to-the-add-mentor-flow.md
@@ -29,6 +29,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: funding-mentors-adding-mentors-date-of-birth
+    title: Adding date of birth to the ‘Add mentor’ flow
 ---
 
 Previously, when users wanted to add a mentor to the service, they simply needed to enter a teacher reference number (TRN) to find the teacher in the database of qualified teachers (DQT). This look-up then returned the teacher’s first and last name.

--- a/app/posts/claim-funding-for-mentors/2024-10-15-accessibility-audit.md
+++ b/app/posts/claim-funding-for-mentors/2024-10-15-accessibility-audit.md
@@ -7,6 +7,7 @@ tags:
 eleventyComputed:
   eleventyNavigation:
     key: claim-funding-accessibility-audit
+    title: Accessibility audit and remediation
 ---
 
 *[ARIA]: Accessible Rich Internet Applications

--- a/app/posts/manage-school-placements/2023-12-18-adding-organisations-in-support.md
+++ b/app/posts/manage-school-placements/2023-12-18-adding-organisations-in-support.md
@@ -45,6 +45,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-support-adding-organisations
+    title: Adding organisations in Support
 ---
 
 We added a way for the support team to onboard new organisations to the service.

--- a/app/posts/manage-school-placements/2023-12-18-managing-organisation-users-in-support.md
+++ b/app/posts/manage-school-placements/2023-12-18-managing-organisation-users-in-support.md
@@ -47,6 +47,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-support-managing-organisation-users
+    title: Managing organisation users in Support
 ---
 
 We added a way for support team users to manage users belonging to an organisation.

--- a/app/posts/manage-school-placements/2023-12-19-signing-in-to-the-service.md
+++ b/app/posts/manage-school-placements/2023-12-19-signing-in-to-the-service.md
@@ -45,6 +45,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-signing-in-to-the-service
+    title: Signing in to the service
 ---
 
 All users must use the Department for Education (DfE) Sign-in to access Manage school placements.

--- a/app/posts/manage-school-placements/2024-01-11-addding-a-school-when-ther-is-no-javascript-available.md
+++ b/app/posts/manage-school-placements/2024-01-11-addding-a-school-when-ther-is-no-javascript-available.md
@@ -30,6 +30,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-support-add-school-no-js
+    title: Adding a school when JavaScript is unavailable
 ---
 
 When a support user adds a school in Manage school placements, we use an autocomplete to help users search for schools.

--- a/app/posts/manage-school-placements/2024-01-11-adding-an-itt-provider-when-javascript-is-unavailable.md
+++ b/app/posts/manage-school-placements/2024-01-11-adding-an-itt-provider-when-javascript-is-unavailable.md
@@ -29,6 +29,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-support-add-provider-no-js
+    title: Adding an ITT provider when JavaScript is unavailable
 ---
 
 When support users add an ITT provider in Manage school placements, we use an autocomplete to help them search for the provider.

--- a/app/posts/manage-school-placements/2024-01-12-managing-support-users.md
+++ b/app/posts/manage-school-placements/2024-01-12-managing-support-users.md
@@ -47,6 +47,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-managing-support-users
+    title: Managing support users
 ---
 
 We added a way for the support team to manage access to Support for Manage school placements (Support).

--- a/app/posts/manage-school-placements/2024-02-09-adding-mentors.md
+++ b/app/posts/manage-school-placements/2024-02-09-adding-mentors.md
@@ -39,6 +39,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-adding-mentors
+    title: Adding mentors
 ---
 
 We added a way for schools to add their mentors to Manage school placements (Placements).

--- a/app/posts/manage-school-placements/2024-02-12-adding-mentors-in-support.md
+++ b/app/posts/manage-school-placements/2024-02-12-adding-mentors-in-support.md
@@ -39,6 +39,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-support-adding-organisation-mentors
+    title: Adding mentors in Support
 ---
 
 We added a way for Support users to manage mentors belonging to a school.

--- a/app/posts/manage-school-placements/2024-03-27-collecting-feedback-about-the-service.md
+++ b/app/posts/manage-school-placements/2024-03-27-collecting-feedback-about-the-service.md
@@ -21,6 +21,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-collecting-feedback
+    title: Collecting feedback about the service
 ---
 
 > Update: We will collect feedback via a Microsoft form instead of building a form within the service.

--- a/app/posts/manage-school-placements/2024-04-23-service-error-pages.md
+++ b/app/posts/manage-school-placements/2024-04-23-service-error-pages.md
@@ -30,6 +30,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: manage-placements-service-error-pages
+    title: Service error pages
 ---
 
 We added the service error pages used when:

--- a/app/posts/manage-school-placements/2024-04-29-adding-date-of-birth-to-the-add-mentor-flow.md
+++ b/app/posts/manage-school-placements/2024-04-29-adding-date-of-birth-to-the-add-mentor-flow.md
@@ -29,6 +29,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-adding-mentors-date-of-birth
+    title: Adding date of birth to the ‘Add mentor’ flow
 ---
 
 Previously, when users wanted to add a mentor to the service, they simply needed to enter a teacher reference number (TRN) to find the teacher in the database of qualified teachers (DQT). This look-up then returned the teacher’s first and last name.

--- a/app/posts/manage-school-placements/2024-07-15-the-lifecycle-of-a-school-placement.md
+++ b/app/posts/manage-school-placements/2024-07-15-the-lifecycle-of-a-school-placement.md
@@ -15,6 +15,7 @@ related:
 eleventyComputed:
   eleventyNavigation:
     key: school-placements-lifecycle-of-a-school-placement
+    title: The lifecycle of a school placement
 ---
 
 The lifecycle of a school placement differs according to the school, ITT provider, and trainee. We are testing our understanding of a typical placement lifecycle through the Manage school placements private beta.

--- a/app/posts/register-of-placement-schools/2025-07-23-clarifying-how-a-placement-school-differs-from-a-school.md
+++ b/app/posts/register-of-placement-schools/2025-07-23-clarifying-how-a-placement-school-differs-from-a-school.md
@@ -1,7 +1,7 @@
 ---
 title: Clarifying how a placement school differs from a school
 description: Understanding what we mean by a ‘placement school’ is essential to building the register
-date: 2025-07-23
+date: 2025-07-23T12:00:00+00:00
 tags:
   - placement schools
   - register

--- a/app/posts/register-of-placement-schools/2025-07-25-naming-the-service.md
+++ b/app/posts/register-of-placement-schools/2025-07-25-naming-the-service.md
@@ -16,6 +16,7 @@ related:
 eleventyComputed:
   eleventyNavigation:
     key: register-placement-schools-naming-the-service
+    title: Naming the service ‘Register of placement schools’
 ---
 
 The name of a service does a lot of heavy lifting. It should make sense to the people who need to use it, stand up to scrutiny, and remain relevant as the service develops.

--- a/app/posts/register-of-training-providers/2025-01-30-naming-the-service.md
+++ b/app/posts/register-of-training-providers/2025-01-30-naming-the-service.md
@@ -1,5 +1,5 @@
 ---
-title: "Naming the service: Register of training providers"
+title: Naming the service ‘Register of training providers’
 description: Choosing the right name for a service is essential to its success
 date: 2025-01-30
 tags:
@@ -14,6 +14,7 @@ related:
 eleventyComputed:
   eleventyNavigation:
     key: register-training-providers-naming-the-service
+    title: Naming the service ‘Register of training providers’
 ---
 
 Choosing the right name for a service is essential to its success.

--- a/app/posts/register-of-training-providers/2025-03-11-managing-support-users.md
+++ b/app/posts/register-of-training-providers/2025-03-11-managing-support-users.md
@@ -59,6 +59,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: register-training-providers-managing-support-users
+    title: Managing support users
 ---
 
 We added a way for the support team to manage access to the Register of training providers.

--- a/app/posts/register-of-training-providers/2025-04-02-service-error-pages.md
+++ b/app/posts/register-of-training-providers/2025-04-02-service-error-pages.md
@@ -36,6 +36,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: register-training-providers-error-pages
+    title: Service error pages
 ---
 
 We added the service error pages used when:

--- a/app/posts/register-of-training-providers/2025-04-03-collecting-feedback-about-the-service.md
+++ b/app/posts/register-of-training-providers/2025-04-03-collecting-feedback-about-the-service.md
@@ -29,6 +29,7 @@ screenshots:
 eleventyComputed:
   eleventyNavigation:
     key: register-training-providers-collecting-feedback
+    title: Collecting feedback about the service
 ---
 
 We added a way for users to tell us what they think of the service.


### PR DESCRIPTION
Design history posts need a unique page slug for Eleventy navigation to work correctly.

When two posts have the same page slug (for example, `naming-the-service`), we need to specify a unique page slug using `eleventyComputed`. For example:

```
eleventyComputed:
  eleventyNavigation:
    key: register-of-training-providers-naming-the-service
```

However, if we do not specify the title of the post as well, in places such as the sitemap, users will see the slug `register-of-training-providers-naming-the-service` rather than the post title `Naming the service ‘Register of training providers’`. To solve this, we need to include the page title. For example:

```
eleventyComputed:
  eleventyNavigation:
    key: register-of-training-providers-naming-the-service
    title: Naming the service ‘Register of training providers’
```