### PR TITLE
Add ‘Register of placement schools’ to serviceLabel filter

### DIFF
--- a/lib/filters/serviceName.js
+++ b/lib/filters/serviceName.js
@@ -7,6 +7,7 @@ module.exports = function (slug) {
     'manage-school-placements': 'Manage school placements',
     'manage-teacher-training-applications': 'Manage teacher training applications',
     'publish-teacher-training-courses': 'Publish teacher training courses',
+    'register-of-placement-schools': 'Register of placement schools',
     'register-of-training-providers': 'Register of training providers',
     'register-trainee-teachers': 'Register trainee teachers',
     'support-for-publish': 'Support for Publish teacher training courses',


### PR DESCRIPTION
This PR adds the ‘Register of placement schools’ to the Nunjucks serviceLabel filter. We use this filter when displaying posts in the tagged posts lists. 

For example, this is the ’accredited providers’ tagged list: https://deploy-preview-1746--bat-design-history.netlify.app/tags/accredited-providers/