### PR TITLE
Fix content

### DIFF
--- a/app/posts/claim-funding-for-mentors/2024-09-30-managing-payments-in-support.md
+++ b/app/posts/claim-funding-for-mentors/2024-09-30-managing-payments-in-support.md
@@ -93,7 +93,7 @@ The payment section is empty until we receive a response from the ESFA; there ar
 
 > There are no claims waiting to be processed.
 
-![Screenshot showing the payments section empty state](payments--default.png ‘Screenshot showing the payments section empty state')
+![Screenshot showing the payments section empty state](payments--default.png "Screenshot showing the payments section empty state")
 
 ### List of claims
 

--- a/app/posts/claim-funding-for-mentors/2024-10-03-sampling-claims-in-support.md
+++ b/app/posts/claim-funding-for-mentors/2024-10-03-sampling-claims-in-support.md
@@ -89,7 +89,7 @@ The sampling section is empty until we upload the claims to be sampled. In this 
 
 > There are no claims waiting to be processed.
 
-![Screenshot showing the sampling section empty state](sampling--default.png ‘Screenshot showing the sampling section empty state')
+![Screenshot showing the sampling section empty state](sampling--default.png 'Screenshot showing the sampling section empty state')
 
 ### List of claims
 

--- a/app/posts/claim-funding-for-mentors/2024-10-03-sampling-claims-in-support.md
+++ b/app/posts/claim-funding-for-mentors/2024-10-03-sampling-claims-in-support.md
@@ -89,7 +89,7 @@ The sampling section is empty until we upload the claims to be sampled. In this 
 
 > There are no claims waiting to be processed.
 
-![Screenshot showing the sampling section empty state](sampling--default.png 'Screenshot showing the sampling section empty state')
+![Screenshot showing the sampling section empty state](sampling--default.png "Screenshot showing the sampling section empty state")
 
 ### List of claims
 

--- a/app/posts/claim-funding-for-mentors/2024-10-11-clawing-back-claims-via-support-after-they-have-been-paid.md
+++ b/app/posts/claim-funding-for-mentors/2024-10-11-clawing-back-claims-via-support-after-they-have-been-paid.md
@@ -132,7 +132,7 @@ The filter sidebar includes filters for:
 - accredited providers
 - schools
 
-#### Claim status
+#### Claim status filter
 
 We show a list of checkboxes containing the clawback claim statuses:
 


### PR DESCRIPTION
This PR fixes content on 3 Claim funding for mentor training posts. See the ‘Files changed‘ tab for more context on what has changed.