### PR TITLE
Fix post: End of cycle 2025

### DIFF
--- a/app/posts/apply-for-teacher-training/2025-10-27-end-of-cycle-carryover.md
+++ b/app/posts/apply-for-teacher-training/2025-10-27-end-of-cycle-carryover.md
@@ -6,32 +6,32 @@ tags:
   - End of cycle
   - Cycle dates
 ---
-## Background
 
-After the recruitment cycle closes, we perform some tasks in the background to 'carry over' candidates' application details to the next cycle. This means they can start submitting applications as soon as the new cycle opens without having to complete all of their personal details again.
+After the recruitment cycle closes, we perform some tasks in the background to ‘carry over’ candidates’ application details to the next cycle. This means they can start submitting applications as soon as the new cycle opens without having to complete all of their personal details again.
 
-There are some sections of a candidate's details that we need them to reconfirm before they can apply again. These are:
+There are some sections of a candidate’s details that we need them to reconfirm before they can apply again. These are:
 
-* equality and diversity information
-* reference information
-* for this cycle only, [whether they have started an ITT course in the past](https://becoming-a-teacher.design-history.education.gov.uk/apply-for-teacher-training/disclose-previous-itt/)
+- equality and diversity information
+- reference information
+- for this cycle only, [whether they have started an ITT course in the past](/apply-for-teacher-training/disclose-previous-itt/)
 
-However the screen that they see doesn't specify much of this information, there's just a single green button that says 'Update your details'. "Update your details' is also the only way to access both the Your details page and your old applications which are linked from the Your details page.
+However the screen that they see does not specify much of this information, there’s just a single green button that says ‘Update your details’. "Update your details’ is also the only way to access both the Your details page and your old applications which are linked from the Your details page.
 
-We also don't give them specific information depending on the scenario they are in. For example, a candidate who had open offers and open applications when the reject by default deadline happened, might need to know different things than someone who has no open applications or offers.
+We also do not give them specific information depending on the scenario they are in. For example, a candidate who had open offers and open applications when the reject by default deadline happened, might need to know different things than someone who has no open applications or offers.
 
 ## What did we do
 
 ### Content changes
 
 On the Your details page we added some inset text at the top of the screen to let candidates know which sections they should update before they can submit new applications:
+
 ![Inset-text explaining that they should update equality and diversity, references and previous ITT sections](your-details.png)
 
 On the Your applications page we added content to make it clearer what place in the cycle they are in, what needs to be updated and why before they can move on to applying:
 
 ![Updated-content-explaining-which-content-to-update](carry-over-new-content.png)
 
-The box-out at the bottom of Your details previously said that someone could start applying to courses once their details are complete. This isn't true during carry-over when the recruitment cycle hasn't opened yet.
+The box-out at the bottom of Your details previously said that someone could start applying to courses once their details are complete. This is not true during carry-over when the recruitment cycle has not opened yet.
 
 ![Box-out saying you can start submitting applications](as-is-start-applications.png)
 
@@ -42,51 +42,51 @@ Button: Choose a course
 
 #### After the apply deadline but before the reject by default deadline
 
-* If someone has open applications but no offers:
-If you don't hear back from training providers about your applications before 11:59pm UK time on 24 September then they will be rejected automatically.
+- If someone has open applications but no offers:
+If you don’t hear back from training providers about your applications before 11:59pm UK time on 24 September then they will be rejected automatically.
 
-* If someone has no open applications but they do have offers:
-You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don't respond before this time.
+- If someone has no open applications but they do have offers:
+You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don’t respond before this time.
 
-* If someone has both open applications and open offers:
-You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don't respond before this time.
+- If someone has both open applications and open offers:
+You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don’t respond before this time.
 
-If you don't hear back from training providers about your applications before 11:59pm UK time on 24 September then they will be rejected automatically.
+If you don’t hear back from training providers about your applications before 11:59pm UK time on 24 September then they will be rejected automatically.
 
 #### After the reject by default deadline but before the decline by default deadline
 
-* If someone has open applications but no offers:
+- If someone has open applications but no offers:
 Some of your applications have been rejected automatically. This is because training providers did not respond to them before the deadline of 11:59pm UK time on 24 September.
 
-* If someone has no open applications but they do have offers:
-You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don't respond before this time.
+- If someone has no open applications but they do have offers:
+You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don’t respond before this time.
 
-* If someone has both open applications and open offers:
+- If someone has both open applications and open offers:
 Some of your applications have been rejected automatically. This is because training providers did not respond to them before the deadline of 11:59pm UK time on 24 September.
 
-You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don't respond before this time.
+You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don’t respond before this time.
 
 #### After the decline by default deadline
 
-* If someone has open applications but no offers:
+- If someone has open applications but no offers:
 Same as in the above scenario.
 
-* If someone has no open applications but they do have offers:
+- If someone has no open applications but they do have offers:
 Any offers that you had received have been declined on your behalf because you did not respond before the deadline of 11:59pm UK time on 28 September. Contact the training provider if you need to discuss this.
 
-* If someone has both open applications and open offers:
+- If someone has both open applications and open offers:
 Some of your applications have been rejected automatically. This is because training providers did not respond to them before the deadline of 11:59pm UK time on 24 September.
 
 Any offers that you had received have been declined on your behalf because you did not respond before the deadline of 11:59pm UK time on 28 September. Contact the training provider if you need to discuss this.
 
 Note that in some circumstances, multiple blocks of content should be shown. Where this is the case, the offer content should come first (as it contains an action).
 
-## What's next
+## What’s next
 
-![As-is Your applications screen during 'carry over'](as-is-carry-over.png)
+![As-is Your applications screen during ‘carry over’](as-is-carry-over.png)
 
-Candidates could only see their previous applications by clicking the 'Update your details' button, which isn't very intuitive.
+Candidates could only see their previous applications by clicking the ‘Update your details’ button, which is not very intuitive.
 
-We have a card in the backlog to move the previous applications from the 'Your details' screen to the 'Your applications' dashboard screen because this seems like a more logical place to find it. We will also redesign the way previous applications are displayed to make them more consistent with the rest of the service.
+We have a card in the backlog to move the previous applications from the ‘Your details’ screen to the ‘Your applications’ dashboard screen because this seems like a more logical place to find it. We will also redesign the way previous applications are displayed to make them more consistent with the rest of the service.
 
-We plan to remove the 'Update your details' button and change the carry-over mechanism so that it's triggered by a candidate updating any of their information. It was felt these changes were too significant to risk doing at the start of the cycle so we have moved them to a time when we are into the new cycle so the risk is lower and we have time to test properly.
+We plan to remove the ‘Update your details’ button and change the carry-over mechanism so that it’s triggered by a candidate updating any of their information. It was felt these changes were too significant to risk doing at the start of the cycle so we have moved them to a time when we are into the new cycle so the risk is lower and we have time to test properly.

--- a/app/posts/apply-for-teacher-training/2025-10-27-end-of-cycle-carryover.md
+++ b/app/posts/apply-for-teacher-training/2025-10-27-end-of-cycle-carryover.md
@@ -3,8 +3,8 @@ title: End of cycle 2025
 description: Changes we made during the ‘carry over’ period
 date: 2025-10-27
 tags:
-  - End of cycle
-  - Cycle dates
+  - end of cycle
+  - cycle dates
 ---
 
 After the recruitment cycle closes, we perform some tasks in the background to ‘carry over’ candidates’ application details to the next cycle. This means they can start submitting applications as soon as the new cycle opens without having to complete all of their personal details again.

--- a/app/posts/apply-for-teacher-training/2025-10-27-end-of-cycle-carryover.md
+++ b/app/posts/apply-for-teacher-training/2025-10-27-end-of-cycle-carryover.md
@@ -1,6 +1,6 @@
 ---
-title: "End of cycle 2025"
-description: Changes we made during the 'carryover' period
+title: End of cycle 2025
+description: Changes we made during the ‘carry over’ period
 date: 2025-10-27
 tags:
   - End of cycle
@@ -40,7 +40,7 @@ You have completed your details
 You can start your applications.
 Button: Choose a course
 
-**After the apply deadline but before the reject by default deadline**
+#### After the apply deadline but before the reject by default deadline
 
 * If someone has open applications but no offers:
 If you don't hear back from training providers about your applications before 11:59pm UK time on 24 September then they will be rejected automatically.
@@ -53,7 +53,7 @@ You have until 11:59pm UK time on 28 September to respond to any offers you rece
 
 If you don't hear back from training providers about your applications before 11:59pm UK time on 24 September then they will be rejected automatically.
 
-**After the reject by default deadline but before the decline by default deadline**
+#### After the reject by default deadline but before the decline by default deadline
 
 * If someone has open applications but no offers:
 Some of your applications have been rejected automatically. This is because training providers did not respond to them before the deadline of 11:59pm UK time on 24 September.
@@ -66,7 +66,7 @@ Some of your applications have been rejected automatically. This is because trai
 
 You have until 11:59pm UK time on 28 September to respond to any offers you receive. They will be declined on your behalf if you don't respond before this time.
 
-**After the decline by default deadline**
+#### After the decline by default deadline
 
 * If someone has open applications but no offers:
 Same as in the above scenario.


### PR DESCRIPTION
This post fixes markdown lint errors caused by using emphasis instead of headings.