### PR TITLE
Update post: Geocoding addresses

### DIFF
--- a/app/posts/find-teacher-training/2025-12-12-filtering-and-sorting-ur.md
+++ b/app/posts/find-teacher-training/2025-12-12-filtering-and-sorting-ur.md
@@ -59,10 +59,15 @@ We conducted semi-structured remote interviews with participants via video call.
 Each session lasted approximately one hour and included the following activities:
 
 ### 1. Prototype interaction
+
 Observed participants as they explored the prototype, focusing on new filtering and sorting designs.
+
 ### 2. Feedback collection
+
 Captured participants’ perceptions and usability feedback on the redesigned filter and sorting features.
+
 ### 3. Targeted feature testing
+
 Asked participants to complete tasks using specific filtering functions to assess clarity, efficiency, and overall usability.
 
 ## What we tested
@@ -87,6 +92,7 @@ The designs we tested included:
 We iterated on the designs during the round of research, based on user insights or team discussion.
 
 ### Filter background colour
+
 When [researching filters across government](/find-teacher-training/researching-filters-across-government/) we found filters on either a grey or white background. We wanted to test on both, to see if this made any difference.
 
  <img alt="Screenshot of the iteration of changing the filtering background from light grey to white" src="filtering-iteration-grey-white-bg.png">

--- a/app/posts/register-of-training-providers/2025-02-24-geocoding-addresses.md
+++ b/app/posts/register-of-training-providers/2025-02-24-geocoding-addresses.md
@@ -26,6 +26,8 @@ screenshots:
       src: provider-details.png
 ---
 
+> **Update 4 December 2025:** Previously, we mentioned using the Google Maps API to geocode addresses. We do not need to do this as the Ordnance Survey API returns latitude and longitude information for each address.
+
 Previously, we gave users the ability to [manage provider addresses](/register-of-training-providers/managing-provider-addresses/) and [add an address using a postcode address finder](/register-of-training-providers/adding-an-address-using-a-postcode-address-finder/). This work enables us to collect accurate and reliable address data.
 
 To increase the utility of the address data, we need to geocode addresses as well.


### PR DESCRIPTION
This PR adds the message:

> **Update 4 December 2025:** Previously, we mentioned using the Google Maps API to geocode addresses. We do not need to do this as the Ordnance Survey API returns latitude and longitude information for each address.

View post: https://deploy-preview-1840--bat-design-history.netlify.app/register-of-training-providers/geocoding-addresses/