### PR TITLE
Update the HPITT cohort dates

### DIFF
--- a/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
+++ b/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
@@ -27,11 +27,11 @@ eleventyComputed:
 
 > This design history does not constitute guidance for training providers - it is an internal document for use by digital teams
 
-As detailed in [Initial teacher training (ITT): forming partnerships](https://www.gov.uk/government/publications/initial-teacher-training-itt-forming-partnerships), from September 2024, “all ITT that leads to QTS should be defined within three core routes (undergraduate fee-funded, postgraduate fee-funded, and postgraduate employment based).”
+As detailed in [Initial teacher training (ITT): forming partnerships](https://www.gov.uk/government/publications/initial-teacher-training-itt-forming-partnerships), from September 2024, "all ITT that leads to QTS should be defined within three core routes (undergraduate fee-funded, postgraduate fee-funded, and postgraduate employment based)."
 
-Since the publication of this document, the salaried teacher degree apprenticeship (TDA) has been launched. As a result, there are now four core routes: undergraduate fee-funded and salaried, postgraduate fee-funded, and employment-based.
+Since the publication of this document, the salaried teacher degree apprenticeship (TDA) has been launched. As a result, there are now 4 core routes: undergraduate fee-funded and salaried, postgraduate fee-funded, and employment-based.
 
-Within these core four routes, there are 7 avenues into teaching for domestic candidates. These routes are split between undergraduate and postgraduate initial teacher training (ITT) and assessment only.
+Within these core 4 routes, there are 7 avenues into teaching for domestic candidates. These routes are split between undergraduate and postgraduate initial teacher training (ITT) and assessment only.
 
 International candidates may be eligible for all these routes into teaching if they meet visa and residency requirements.
 
@@ -69,7 +69,7 @@ Postgraduate ITT has 4 routes:
 - postgraduate teacher apprenticeship (PGTA)
 - high potential initial teacher training (HPITT)
 
-Except for the assessment-only route, all postgraduate ITT routes often include a postgraduate certificate of education (PGCE)  or professional graduate diploma in education (PGDE) alongside QTS.
+Except for the assessment-only route, all postgraduate ITT routes often include a postgraduate certificate of education (PGCE) or professional graduate diploma in education (PGDE) alongside QTS.
 
 A PGCE is an internationally recognised academic qualification.
 

--- a/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
+++ b/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
@@ -27,7 +27,7 @@ eleventyComputed:
 
 > This design history does not constitute guidance for training providers - it is an internal document for use by digital teams
 
-As detailed in [Initial teacher training (ITT): forming partnerships](https://www.gov.uk/government/publications/initial-teacher-training-itt-forming-partnerships), from September 2024, "all ITT that leads to QTS should be defined within three core routes (undergraduate fee-funded, postgraduate fee-funded, and postgraduate employment based)."
+As detailed in [Initial teacher training (ITT): forming partnerships](https://www.gov.uk/government/publications/initial-teacher-training-itt-forming-partnerships), from September 2024, "all ITT that leads to QTS should be defined within 3 core routes (undergraduate fee-funded, postgraduate fee-funded, and postgraduate employment based)."
 
 Since the publication of this document, the salaried teacher degree apprenticeship (TDA) has been launched. As a result, there are now 4 core routes: undergraduate fee-funded and salaried, postgraduate fee-funded, and employment-based.
 

--- a/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
+++ b/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
@@ -91,6 +91,6 @@ The high-potential ITT route is a national 2-year employment-based initial teach
 
 [Teach First](https://www.teachfirst.org.uk/) delivers the current HPITT contract and covers cohorts up to and including the ITT2026 cohort (academic year 2026 to 2027).
 
-## Assessment only (AO)
+### Assessment only (AO)
 
 Assessment only is a route to QTS for teaching staff who already meet the teachers’ standards, have the requisite teaching experience, and do not need further training. AO entails a series of assessments over 12 weeks to show how candidates meet the teachers’ standards.

--- a/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
+++ b/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
@@ -91,6 +91,6 @@ The high-potential ITT route is a national 2-year employment-based initial teach
 
 [Teach First](https://www.teachfirst.org.uk/) delivers the current HPITT contract and covers cohorts up to and including the ITT2026 cohort (academic year 2026 to 2027).
 
-### Assessment only (AO)
+## Assessment only (AO)
 
 Assessment only is a route to QTS for teaching staff who already meet the teachers’ standards, have the requisite teaching experience, and do not need further training. AO entails a series of assessments over 12 weeks to show how candidates meet the teachers’ standards.

--- a/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
+++ b/app/posts/becoming-a-teacher/2024-07-15-routes-into-teaching.md
@@ -89,7 +89,7 @@ The postgraduate teacher apprenticeship route allows candidates to learn ‘on t
 
 The high-potential ITT route is a national 2-year employment-based initial teacher training and leadership development programme that seeks to recruit and train high-potential graduates and career changers who would be otherwise unlikely to join the profession or work in a school serving an area of greatest need.
 
-[Teach First](https://www.teachfirst.org.uk/) delivers the current HPITT contract and covers cohorts up to and including the ITT2025 cohort (academic year 2025 to 2026).
+[Teach First](https://www.teachfirst.org.uk/) delivers the current HPITT contract and covers cohorts up to and including the ITT2026 cohort (academic year 2026 to 2027).
 
 ## Assessment only (AO)
 


### PR DESCRIPTION
Following a request from the Targeted recruitment and delivery team, this PR updates the HPITT cohort dates in the [Routes into teaching for domestic candidates](https://deploy-preview-1910--bat-design-history.netlify.app/becoming-a-teacher/routes-into-teaching/) post from:

> ITT2025 cohort (academic year 2025 to 2026)

To:

> ITT2026 cohort (academic year 2026 to 2027)

The contract has been extended for one further cohort.

View post: https://deploy-preview-1910--bat-design-history.netlify.app/becoming-a-teacher/routes-into-teaching/